### PR TITLE
Fix the in page anchors blocked by navbar

### DIFF
--- a/src/Navbar.vue
+++ b/src/Navbar.vue
@@ -88,6 +88,7 @@ export default {
     let height = this.$el.offsetHeight
     if (this.placement === 'top') {
       document.body.style.paddingTop = height + 'px'
+      $(window).on('hashchange', () => scrollBy(0, -height))
     }
     if (this.placement === 'bottom') {
       document.body.style.paddingBottom = height + 'px'


### PR DESCRIPTION
This PR tries to fix https://github.com/MarkBind/markbind/issues/152

The issue occurs because the `navbar` is fixed at the top of the page, which means it will always block the target content of any in page links. This is kind of a known issue to Bootstrap, see their discuss here https://github.com/twbs/bootstrap/issues/1768

Tried to fix by adjusting the scrolling when the hash part of the URL changes.