### PR TITLE
Fix popover position for mobile browsers

### DIFF
--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -25,7 +25,6 @@ export default {
     'trigger:bind': function (el, id) {
       if (id === this.id) {
         el.setTriggerBy(this)
-        this.setTrigger(el) // rebind events
       }
     }
   },

--- a/src/Tooltip.vue
+++ b/src/Tooltip.vue
@@ -35,7 +35,6 @@ export default {
     'trigger:bind': function (el, id) {
       if (id === this.id) {
         el.setTriggerBy(this)
-        this.setTrigger(el) // rebind events
       }
     }
   },

--- a/src/trigger.vue
+++ b/src/trigger.vue
@@ -14,19 +14,16 @@
       },
       _triggerBy: {
         type: Object
-      },
-      _isBinded: {
-        type: Boolean,
-        default: false
       }
     },
     attached () {
       let events = {contextmenu: 'contextmenu', hover: 'mouseleave mouseenter', focus: 'blur focus'}
-      jQuery(this.$el).on(events[this.trigger] || 'click', () => {
+      jQuery(this.$el).on(events[this.trigger] || 'click', (e) => {
+        if (e && this.trigger === 'contextmenu') e.preventDefault()
         if (!this._triggerBy) {
           this.$dispatch('trigger:register', this, this.for)
-          this._triggerBy && this._triggerBy.toggle()
         }
+        this._triggerBy && this._triggerBy.toggle(e)
       })
 
       this.$els.trigger.style['border-bottom'] = (this.trigger === 'click') ? '1px dashed #333' : '1px dotted #333'
@@ -37,13 +34,8 @@
     },
     methods: {
       setTriggerBy (vm) {
-        if (!this._isBinded) {
-        let events = {contextmenu: 'contextmenu', hover: 'mouseleave mouseenter', focus: 'blur focus'}
-          this._isBinded = true
-          this._triggerBy = vm
-          jQuery(this.$el).on(events[this.trigger] || 'click', this._triggerBy.toggle)
-        }
-       }
+        this._triggerBy = vm
+      }
     }
   }
 </script>

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -2,6 +2,14 @@ import {coerce} from './utils.js'
 import $ from './NodeList.js'
 import md from './markdown.js'
 
+function getFirst(nodeList) {
+  return nodeList && (nodeList.length ? nodeList[0] : nodeList)
+}
+
+function getFirstChild(node) {
+  return node && (node.children.length ? node.children[0] : node)
+}
+
 export default {
   props: {
     trigger: {
@@ -48,25 +56,17 @@ export default {
     }
   },
   methods: {
-    /**
-     * Reset the trigger element
-     * @param el a Vue instance
-     */
-    setTrigger (el) {
-      this.trigger = el.trigger // trigger event
-      this._trigger = el.$el
-    },
     toggle (e) {
-      if (e && this.trigger === 'contextmenu') e.preventDefault()
+      let trigger = getFirstChild(this.$els.trigger)
+      if (e && this.trigger === 'contextmenu' && trigger === e.target) e.preventDefault()
       if (!(this.show = !this.show)) {
         return
       }
-      let trigger = this._trigger.children.length === 0 ? this._trigger : this._trigger.children[0]
       if (e) {
         let target = e.target
-        if (trigger != e.target) {
+        if (trigger !== target && getFirst(this._trigger) !== target) {
           // Multiple triggers share this popover
-          trigger = target.children.length === 0 ? target : target.children[0]
+          trigger = getFirstChild(target)
         }
       }
       setTimeout(() => {

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -74,12 +74,14 @@ export default {
         console.log(trigger.offsetTop)
         console.log(popover.offsetHeight)
         this.calculateOffset(trigger, popover)
+        this.updateOffsetForMargins(popover)
         popover.style.top = this.position.top + 'px'
         popover.style.left = this.position.left + 'px'
         if (this.$els.arrow) {
           let actualWidth  = popover.offsetWidth
           let actualHeight = popover.offsetHeight
           this.calculateOffset(trigger, popover) // Update for CSS adjustment
+          this.updateOffsetForMargins(popover)
           let delta = this.getViewportAdjustedDelta(this.position, actualWidth, actualHeight)
           if (delta.left) this.position.left += delta.left
           else this.position.top += delta.top
@@ -112,6 +114,17 @@ export default {
           break
         default:
           console.warn('Wrong placement prop')
+      }
+    },
+    updateOffsetForMargins (popover) {
+      const rect = popover.getBoundingClientRect()
+      if (rect.left < 0) {
+        this.position.left -= rect.left
+        const marginLeft = parseInt(jQuery(popover).css('margin-left'), 10)
+        if (marginLeft < 0) {
+          this.position.left += marginLeft
+          popover.style.marginLeft = 0
+        }
       }
     },
     getViewportAdjustedDelta (pos, actualWidth, actualHeight) {


### PR DESCRIPTION
Fixes MarkBind/markbind#50
Resolves #6
Reverts part of #12 (no regression observed)

## Key changes

- Fix popover offset for left margin in `updateOffsetForMargins`
  Looks hacky, but it's carefully tuned (no fix upstream in https://github.com/yuche/vue-strap).
- Don't replace the original trigger element
  Replacing meant that only the last-registered trigger was tracked, cleaner to pass `e` instead.
- Use `this.$els.trigger` instead of `this._trigger`
  Former refers to the original `v-el:trigger`, latter refers to inner element (for `'focus'` event).
  Check `this._trigger[0] !== target` so that the original trigger is used to position a popover.

## Preview

The *dist* and *docs* have not been updated, to avoid conflicts with the other soon-to-merge PR.

Type | Before | After
-- | -- | --
Popover on left | <img width=300 alt="popover on left" src="https://user-images.githubusercontent.com/14091939/38210849-286d10c6-36eb-11e8-944a-ccbebecb49bc.png" /> | <img width=300 alt="popover on left" src="https://user-images.githubusercontent.com/14091939/38210848-283fc0e4-36eb-11e8-9b47-799c31e15b7e.png" />
Mouseenter | <img width=300 alt="mouseenter" src="https://user-images.githubusercontent.com/14091939/35262237-c0b30cc4-004e-11e8-8816-e8c9cedd46b1.jpg"> | <img width=300 alt="mouseenter" src="https://user-images.githubusercontent.com/14091939/38211386-e0863380-36ec-11e8-9e2a-dcdeeec1afce.png" />
Focus | <img width=300 alt="focus" src="https://user-images.githubusercontent.com/14091939/38211820-3f676e72-36ee-11e8-9db4-2baa14581327.png" /> | <img width=300 alt="focus" src="https://user-images.githubusercontent.com/14091939/38211819-3f310864-36ee-11e8-97fc-1eb7c24d6a31.jpg" />
Hover | <img width=300 alt="hover" src="https://user-images.githubusercontent.com/14091939/35262240-c26e8926-004e-11e8-9db2-29a8de95bd76.jpg"> | <img width=300 alt="hover" src="https://user-images.githubusercontent.com/14091939/38210846-27cfda72-36eb-11e8-9add-d361aebc4af2.png" />
Popover on top / Wrap Text (on Schedule page) | <img width=300 src="https://user-images.githubusercontent.com/14091939/38210847-280cb79e-36eb-11e8-9eb6-c2243478de18.png" /> | No change
Popover on top / Wrap Text (on inner page) | <img width=300 src="https://user-images.githubusercontent.com/16644412/35185358-3841c626-fe3e-11e7-9eee-bc8107f739f3.PNG" /> | <kbd>wontfix</kbd> as it's possible to scroll right