### PR TITLE
Panel: Add line to indicate end of seamless panel

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -47,6 +47,7 @@
                     <panel-switch v-show="canCollapse && bottomSwitch" v-bind:is-open="expanded"
                                   @click.stop.prevent="collapseThenScrollIntoViewIfNeeded()"></panel-switch>
                 </div>
+                <hr v-show="this.type === 'seamless'" />
             </div>
         </div>
     </span>
@@ -298,8 +299,18 @@
         padding: 0;
     }
 
+    .panel-seamless > .panel-collapse > hr {
+        margin: 0;
+        width: calc(100% - 27px);
+    }
+
     .panel-seamless > .panel-collapse > .panel-body {
         padding: 10px 0;
+    }
+
+    .panel-seamless > .panel-collapse > .panel-body > .collapse-button {
+        position: relative;
+        top: 22px;
     }
 
     .panel-body > .collapse-button {


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

?[ ] Documentation update
?[ ] Bug fix
?[ ] New feature
?[x] Enhancement to an existing feature
?[ ] Other, please explain: 

Resolves MarkBind/markbind#22 


What is the rationale for this request?
it's hard to see where the panel content ends and the rest of the page content begins if there is no separator after the panel.

What changes did you make? (Give an overview)
Add grey dashed line under seamless panel in `src/panel.vue`.

Effects:
![image](https://user-images.githubusercontent.com/24241939/39988816-f37400fc-579a-11e8-8d09-2e85f6580f5c.png)


![image](https://user-images.githubusercontent.com/24241939/39988932-3ed58278-579b-11e8-9b6f-7a3e4a48efd7.png)
