### PR TITLE
Tab: Add line to indicate end of tab

### DIFF
--- a/src/Tab.vue
+++ b/src/Tab.vue
@@ -4,6 +4,7 @@
     :transition="transition"
   >
     <slot></slot>
+    <hr />
   </div>
 </template>
 
@@ -72,3 +73,8 @@ export default {
   }
 }
 </script>
+<style>
+    .tab-pane > hr {
+        margin: 0;
+    }
+</style>


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

[ ] Documentation update
[ ] Bug fix
[ ] New feature
[x] Enhancement to an existing feature
[ ] Other, please explain:

Resolves https://github.com/MarkBind/markbind/issues/91

What is the rationale for this request?
Current tab style makes it hard to see where the tab ends.

What changes did you make? (Give an overview)
add line at the end of tab content

Effects: 
![image](https://user-images.githubusercontent.com/24241939/40041030-3ca628e0-584f-11e8-86d3-4de3c2f8eddf.png)

![image](https://user-images.githubusercontent.com/24241939/40041047-4bae0a42-584f-11e8-87a0-8b0af32e304c.png)
