### PR TITLE
Panel: Go from minimized to expanded on open

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -175,6 +175,7 @@
         this.minimized = true;
       },
       open () {
+        this.expanded = true;
         this.minimized = false;
       },
       expandCollapseHandler (isExpand, level) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves MarkBind/markbind#153

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User would like to save 1 click when viewing content of minimized panels

**What changes did you make? (Give an overview)**
- Changed Panel.expanded attribute to true when `open` is called

**Provide a demo**

<!-- Paste the example code below: -->
![paneldemo](https://user-images.githubusercontent.com/31084833/40046979-d019fcb2-5860-11e8-9742-ae2738d298a7.gif)

**Is there anything you'd like reviewers to focus on?**
-NIL-

**Testing instructions:**
1. Minimize a panel.
2. Click on minimized panel, it should expand immediately.