### PR TITLE
Question: Add separation between hint and answer

### DIFF
--- a/src/Question.vue
+++ b/src/Question.vue
@@ -8,13 +8,11 @@
             </div>
         </div>
         <accordion>
-            <div v-show="hasHintSlot">
-                <panel header="Hint" expandable no-close>
-                    <slot name="hint">
-                        No hint is available for this question.
-                    </slot>
-                </panel>
-            </div>
+            <panel v-show="hasHintSlot" header="Hint" expandable no-close>
+                <slot name="hint">
+                    No hint is available for this question.
+                </slot>
+            </panel>
             <panel v-show="hasAnswerSlot" header="Answer" expandable no-close>
                 <slot name="answer"></slot>
             </panel>
@@ -59,6 +57,10 @@
 <style>
     .body-wrapper {
         padding-bottom: 10px;
+    }
+    .question-wrapper > .panel-group > .panel-container + .panel-container {
+        display: block;
+        margin-top: 5px;
     }
     .textarea-container {
         margin: 8px 0;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Related: https://github.com/MarkBind/markbind/pull/211#discussion_r188493596

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

> It doesn't look nice when the two are stuck together.

**What changes did you make? (Give an overview)**

- Remove `<div>` wrapper around hint
- Add `margin-top: 5px;` to [adjacent sibling](https://developer.mozilla.org/en-US/docs/Web/CSS/Adjacent_sibling_selectors) `.panel-container` in `.question-wrapper`

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```html
<question>
    Body
    <div slot="hint">
        Hint
    </div>
    <div slot="answer">
        Answer
    </div>
</question>
```

**Is there anything you'd like reviewers to focus on?**

\-

**Testing instructions:**

- `$ npm run docs`
- Compare with https://markbind.github.io/vue-strap/#question