### PR TITLE
Change style of trigger component

### DIFF
--- a/src/trigger.vue
+++ b/src/trigger.vue
@@ -26,10 +26,13 @@
         this._triggerBy && this._triggerBy.toggle(e)
       })
 
-      this.$els.trigger.style['border-bottom'] = (this.trigger === 'click') ? '1px dashed #333' : '1px dotted #333'
-      this.$els.trigger.style['padding-bottom'] = '2px'
       if (this.trigger === 'click') {
         this.$els.trigger.style['cursor'] = 'pointer'
+        this.$els.trigger.style['-webkit-text-decoration'] = 'underline dashed';
+        this.$els.trigger.style['text-decoration'] = 'underline dashed';
+      } else {
+        this.$els.trigger.style['-webkit-text-decoration'] = 'underline dotted';
+        this.$els.trigger.style['text-decoration'] = 'underline dotted'
       }
     },
     methods: {


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes MarkBind/markbind#111

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial should add a page or unit test for regression testing.
    - Feature PR must add a page to the user guide for demo.
    - Enhancement PR should update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

What is the rationale for this request?
- User encountered bug where highlighted text blocks underlines for trigger elements.

What changes did you make? (Give an overview)
- Modified trigger.vue at `trigger.style` to use `['text-decoration']` instead of `['border']`. 

Provide some example of changes:

Before | After
------------ | -------------
![trigger-underline-before](https://user-images.githubusercontent.com/31084833/40156347-94907a38-59cb-11e8-986b-8edee0757ac8.PNG) | ![trigger-underline-after](https://user-images.githubusercontent.com/31084833/40156353-99f07280-59cb-11e8-80bc-b31db324018f.PNG)

```
Note:
Triggers have a different style when set to "click", which will use dashes. 
Otherwise it defaults to dotted. However, popovers and tool-tips can also 
set "tigger" option to "click" but their style remains as dotted.

Might want to ensure consistency between components in another issue / PR
```

Is there anything you'd like reviewers to focus on?
- Code style

Testing instructions:
1. Type highlighted text using either `<mark>text</mark>` or `<md>==text==</md>` below a trigger element as shown in the example above.