### PR TITLE
Support custom boxes

### DIFF
--- a/docs/example/tipBoxDocs.vue
+++ b/docs/example/tipBoxDocs.vue
@@ -33,6 +33,9 @@
             </tip-box>
             <tip-box color="white" background-color="blue" border-color="darkblue">
                 default with custom colors
+            </tip-box>            
+            <tip-box background-color="white" border-color="grey" border-left-color="blue">
+                empty box with left border
             </tip-box>
         </div>
         <doc-code language="markup">
@@ -68,6 +71,9 @@
             </tip-box>
             <tip-box color="white" background-color="blue" border-color="darkblue">
                 default with custom colors
+            </tip-box>                       
+            <tip-box background-color="white" border-color="grey" border-left-color="blue">
+                empty box with left border
             </tip-box>
         </doc-code>
     </doc-section>

--- a/docs/example/tipBoxDocs.vue
+++ b/docs/example/tipBoxDocs.vue
@@ -76,6 +76,44 @@
                 empty box with left border
             </tip-box>
         </doc-code>
+        <doc-table name="TipBox Options">
+          <div>
+            <p>backgroundColor</p>
+            <p><code>String</code></p>
+            <p><code>null</code></p>
+            <p>Color of the background.</p>
+          </div>
+          <div>
+            <p>borderColor</p>
+            <p><code>String</code></p>
+            <p><code>null</code></p>
+            <p>Color of the entire border.</p>
+          </div>
+          <div>
+            <p>borderLeftColor</p>
+            <p><code>String</code></p>
+            <p><code>null</code></p>
+            <p>Color of the left border.</p>
+          </div>
+          <div>
+            <p>color</p>
+            <p><code>String</code></p>
+            <p><code>null</code></p>
+            <p>Color of the text.</p>
+          </div>
+          <div>
+            <p>icon</p>
+            <p><code>String</code></p>
+            <p><code>null</code></p>
+            <p>Icon to be used inside.</p>
+          </div>
+          <div>
+            <p>type</p>
+            <p><code>String</code>, one of <code>warning</code>, <code>info</code>, <code>definition</code>, <code>success</code>, <code>tip</code>, <code>important</code>, <code>wrong</code>, or empty for default.</p>
+            <p><code>'none'</code></p>
+            <p></p>
+          </div>
+        </doc-table>
     </doc-section>
 </template>
 

--- a/docs/example/tipBoxDocs.vue
+++ b/docs/example/tipBoxDocs.vue
@@ -25,6 +25,15 @@
             <tip-box type="definition">
                 definition
             </tip-box>
+            <tip-box type="info" icon=":rocket:">
+                info but with rocket
+            </tip-box>
+            <tip-box type="info" color="white" background-color="red">
+                info but with different colors
+            </tip-box>
+            <tip-box color="white" background-color="blue" border-color="darkblue">
+                default with custom colors
+            </tip-box>
         </div>
         <doc-code language="markup">
             <tip-box>
@@ -50,6 +59,15 @@
             </tip-box>
             <tip-box type="definition">
                 definition
+            </tip-box>
+            <tip-box type="info" icon=":rocket:">
+                info but with rocket
+            </tip-box>
+            <tip-box type="info" color="white" background-color="red">
+                info but with different colors
+            </tip-box>
+            <tip-box color="white" background-color="blue" border-color="darkblue">
+                default with custom colors
             </tip-box>
         </doc-code>
     </doc-section>

--- a/docs/example/tipBoxDocs.vue
+++ b/docs/example/tipBoxDocs.vue
@@ -1,5 +1,6 @@
 <template>
     <doc-section id="tipBoxDocs" name="TipBox">
+        <p>Alternative alias: box</p>
         <div class="bs-example">
             <tip-box>
                 default
@@ -34,9 +35,9 @@
             <tip-box color="white" background-color="blue" border-color="darkblue">
                 default with custom colors
             </tip-box>            
-            <tip-box background-color="white" border-color="grey" border-left-color="blue">
+            <box background-color="white" border-color="grey" border-left-color="blue">
                 empty box with left border
-            </tip-box>
+            </box>
         </div>
         <doc-code language="markup">
             <tip-box>
@@ -72,9 +73,9 @@
             <tip-box color="white" background-color="blue" border-color="darkblue">
                 default with custom colors
             </tip-box>                       
-            <tip-box background-color="white" border-color="grey" border-left-color="blue">
+            <box background-color="white" border-color="grey" border-left-color="blue">
                 empty box with left border
-            </tip-box>
+            </box>
         </doc-code>
         <doc-table name="TipBox Options">
           <div>

--- a/docs/example/tipBoxDocs.vue
+++ b/docs/example/tipBoxDocs.vue
@@ -1,6 +1,6 @@
 <template>
     <doc-section id="tipBoxDocs" name="TipBox">
-        <p>Alternative alias: box</p>
+        <p>Alias: box</p>
         <div class="bs-example">
             <tip-box>
                 default
@@ -26,18 +26,6 @@
             <tip-box type="definition">
                 definition
             </tip-box>
-            <tip-box type="info" icon=":rocket:">
-                info but with rocket
-            </tip-box>
-            <tip-box type="info" color="white" background-color="red">
-                info but with different colors
-            </tip-box>
-            <tip-box color="white" background-color="blue" border-color="darkblue">
-                default with custom colors
-            </tip-box>            
-            <box background-color="white" border-color="grey" border-left-color="blue">
-                empty box with left border
-            </box>
         </div>
         <doc-code language="markup">
             <tip-box>
@@ -64,37 +52,43 @@
             <tip-box type="definition">
                 definition
             </tip-box>
-            <tip-box type="info" icon=":rocket:">
-                info but with rocket
-            </tip-box>
-            <tip-box type="info" color="white" background-color="red">
-                info but with different colors
-            </tip-box>
-            <tip-box color="white" background-color="blue" border-color="darkblue">
-                default with custom colors
-            </tip-box>                       
+        </doc-code>
+        <br>
+        <h4>Custom boxes</h4>
+        <div class="bs-example">
             <box background-color="white" border-color="grey" border-left-color="blue">
-                empty box with left border
+                default, styled as empty box with blue left border
+            </box>
+            <box type="info" icon=":rocket:">
+                info, with rocket icon
+            </box>
+        </div>
+        <doc-code language="markup">
+            <box background-color="white" border-color="grey" border-left-color="blue">
+                default, styled as empty box with blue left border
+            </box>
+            <box type="info" icon=":rocket:">
+                info, with rocket icon
             </box>
         </doc-code>
-        <doc-table name="TipBox Options">
+        <doc-table name="TipBox">
           <div>
-            <p>backgroundColor</p>
+            <p>background-color</p>
             <p><code>String</code></p>
             <p><code>null</code></p>
-            <p>Color of the background.</p>
+            <p></p>
           </div>
           <div>
-            <p>borderColor</p>
+            <p>border-color</p>
             <p><code>String</code></p>
             <p><code>null</code></p>
-            <p>Color of the entire border.</p>
+            <p></p>
           </div>
           <div>
-            <p>borderLeftColor</p>
+            <p>border-left-color</p>
             <p><code>String</code></p>
             <p><code>null</code></p>
-            <p>Color of the left border.</p>
+            <p>Overrides border-color for the left border.</p>
           </div>
           <div>
             <p>color</p>
@@ -106,13 +100,13 @@
             <p>icon</p>
             <p><code>String</code></p>
             <p><code>null</code></p>
-            <p>Icon to be used inside.</p>
+            <p></p>
           </div>
           <div>
             <p>type</p>
-            <p><code>String</code>, one of <code>warning</code>, <code>info</code>, <code>definition</code>, <code>success</code>, <code>tip</code>, <code>important</code>, <code>wrong</code>, or empty for default.</p>
+            <p><code>String</code></p>
             <p><code>'none'</code></p>
-            <p></p>
+            <p>Support: <code>info</code>, <code>warning</code>, <code>success</code>, <code>important</code>, <code>wrong</code>, <code>tip</code>, <code>definition</code>, or empty for default.</p></p>
           </div>
         </doc-table>
     </doc-section>

--- a/src/Box.vue
+++ b/src/Box.vue
@@ -1,0 +1,6 @@
+<script>
+  import TipBox from './TipBox.vue'
+  export default {
+    extends: TipBox
+  }
+</script>

--- a/src/Box.vue
+++ b/src/Box.vue
@@ -1,6 +1,0 @@
-<script>
-  import TipBox from './TipBox.vue'
-  export default {
-    extends: TipBox
-  }
-</script>

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -21,6 +21,10 @@
         type: String,
         default: null
       },
+      borderLeftColor: {
+        type: String,
+        default: null
+      },
       color: {
         type: String,
         default: null
@@ -63,6 +67,9 @@
         }
         if (this.borderColor) {
           style.borderColor = this.borderColor;
+        }
+        if (this.borderLeftColor) {
+          style.borderLeft = `5px solid ${this.borderLeftColor}`;
         }
         if (this.color) {
           style.color = this.color;

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="alert container" :class="[boxStyle]">
+    <div class="alert container" :class="[boxStyle]" :style="customStyle">
         <div class="icon-wrapper" v-if="!isDefault">
             <span>{{{iconType}}}</span>
         </div>
@@ -13,6 +13,22 @@
   import md from './utils/markdown.js'
   export default {
     props: {
+      backgroundColor: {
+        type: String,
+        default: null
+      },
+      borderColor: {
+        type: String,
+        default: null
+      },
+      color: {
+        type: String,
+        default: null
+      },
+      icon: {
+        type: String,
+        default: null
+      },
       type: {
         type: String,
         default: 'none'
@@ -39,8 +55,24 @@
             return 'alert-default'
         }
       },
-
+      customStyle() {
+        var style = {};
+        if (this.backgroundColor) {
+          style.backgroundColor = this.backgroundColor;
+          style.borderColor = this.backgroundColor;
+        }
+        if (this.borderColor) {
+          style.borderColor = this.borderColor;
+        }
+        if (this.color) {
+          style.color = this.color;
+        }
+        return style;
+      },
       iconType() {
+        if (this.icon) {
+          return md.renderInline(this.icon);
+        }
         switch (this.type) {
           case 'wrong':
             return '❌'

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import accordion from './Accordion.vue'
 import affix from './Affix.vue'
 import alert from './Alert.vue'
 import aside from './Aside.vue'
+import box from './Box.vue'
 import carousel from './Carousel.vue'
 import checkbox from './Checkbox.vue'
 import dropdown from './Dropdown.vue'
@@ -30,6 +31,7 @@ const components = {
   accordion,
   affix,
   aside,
+  box,
   checkbox,
   dropdown,
   dynamicPanel,

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,6 @@ import accordion from './Accordion.vue'
 import affix from './Affix.vue'
 import alert from './Alert.vue'
 import aside from './Aside.vue'
-import box from './Box.vue'
 import carousel from './Carousel.vue'
 import checkbox from './Checkbox.vue'
 import dropdown from './Dropdown.vue'
@@ -31,7 +30,7 @@ const components = {
   accordion,
   affix,
   aside,
-  box,
+  box: tipBox,
   checkbox,
   dropdown,
   dynamicPanel,


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes https://github.com/MarkBind/markbind/issues/69
Fixes https://github.com/MarkBind/markbind/issues/62

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->



**What is the rationale for this request?**

User wants a way to customize tip-boxes with custom colors and icons. User also wants an empty-fill type tip boxes.

**What changes did you make? (Give an overview)**

Added new attributes `color`, `background-color`, `icon`, `border-color` for tip-box customization. Also added a new attribute `border-left-color` to support empty-fill type tip boxes.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```html
<tip-box type="info" icon=":rocket:">
    info but with rocket
</tip-box>
<tip-box type="info" color="white" background-color="red">
    info but with different colors
</tip-box>
<tip-box color="white" background-color="blue" border-color="darkblue">
    default with custom colors
</tip-box>            
<tip-box background-color="white" border-color="grey" border-left-color="blue">
    empty box with left border
</tip-box>
```

**Is there anything you'd like reviewers to focus on?**

Documentation wordings.

**Testing instructions:**

The documentation provides the code under the tip-box section, can use that web page to experiment with the new attributes shown in the documentation.