### PR TITLE
Panel: Add popup window button

### DIFF
--- a/docs/example/accordionDocs.vue
+++ b/docs/example/accordionDocs.vue
@@ -97,15 +97,15 @@
     </doc-code>
     <br>
 
-    <h4>If <code>popup-url</code> attribute is provided, the panel shows a popup button, which when clicked, opens a new window to the specified url.</h4>
+    <h4>If <code>popup-url</code> attribute is provided, a popup button will be shown. If clicked, it opens the specified url in a new window.</h4>
     <div class="bs-example">
-      <panel header="Some panel" popup-url="/docs/loadContent.html">
+      <panel header="Some panel" popup-url="docs/loadContent.html">
         This panel has a popup.
       </panel>
     </div>
     <doc-code language="markup">
-      <panel header="Some panel" popup-url="/docs/loadContent.html">
-        ...
+      <panel header="Some panel" popup-url="docs/loadContent.html">
+        This panel has a popup.
       </panel>
     </doc-code>
     <br>
@@ -241,16 +241,16 @@
         <p>Whether to show the expand switch.</p>
       </div>
       <div>
-        <p>popup-url</p>
-        <p><code>String</code></p>
-        <p></p>
-        <p>The url to display in the popup window.</p>
-      </div>
-      <div>
         <p>bottom-switch</p>
         <p><code>Boolean</code></p>
         <p><code>false</code></p>
         <p>Whether to show an expand switch at the bottom of the panel. Independent of no-switch.</p>
+      </div>
+      <div>
+        <p>popup-url</p>
+        <p><code>String</code></p>
+        <p></p>
+        <p>The url that the popup window will navigate to. The url can be absolute or relative.</p>
       </div>
       <div>
         <p>url</p>

--- a/docs/example/accordionDocs.vue
+++ b/docs/example/accordionDocs.vue
@@ -95,6 +95,20 @@
     <doc-code language="markup">
       <panel header="Dynamic Loading" src="docs/loadContent.html#fragment" minimized></panel>
     </doc-code>
+    <br>
+
+    <h4>If <code>popup-url</code> attribute is provided, the panel shows a popup button, which when clicked, opens a new window to the specified url.</h4>
+    <div class="bs-example">
+      <panel header="Some panel" popup-url="/docs/loadContent.html">
+        This panel has a popup.
+      </panel>
+    </div>
+    <doc-code language="markup">
+      <panel header="Some panel" popup-url="/docs/loadContent.html">
+        ...
+      </panel>
+    </doc-code>
+    <br>
 
     <h4>Accordion could group panels together to provide better control</h4>
     <div class="bs-example">
@@ -225,6 +239,12 @@
         <p><code>Boolean</code></p>
         <p><code>false</code></p>
         <p>Whether to show the expand switch.</p>
+      </div>
+      <div>
+        <p>popup-url</p>
+        <p><code>String</code></p>
+        <p></p>
+        <p>The url to display in the popup window.</p>
       </div>
       <div>
         <p>bottom-switch</p>

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -34,6 +34,11 @@
                                 @click.stop="close()">
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                         </button>
+                        <button type="button" class="popup-button btn btn-default"
+                                v-show="this.popupUrl !== null"
+                                @click.stop="openPopup()">
+                            <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span>
+                        </button>
                     </slot>
                 </div>
             </div>
@@ -109,6 +114,10 @@
         type: Boolean,
         coerce: coerce.boolean,
         default: false
+      },
+      popupUrl: {
+        type: String,
+        default: null
       },
       src: {
         type: String
@@ -200,6 +209,9 @@
           this.scrollIntoViewIfNeeded();
         });
         this.expand();
+      },
+      openPopup() {
+        window.open(this.popupUrl);
       }
     },
     watch: {
@@ -327,6 +339,13 @@
         font-size: 10px !important;
         float: right;
         padding: 3px 8px !important;
+    }
+
+    .popup-button {
+        font-size: 10px !important;
+        float: right;
+        padding: 3px 8px !important;
+        margin-right: 4px;
     }
 
     .morph {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] New feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Resolves https://github.com/MarkBind/markbind/issues/225

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User wants a way to add popup windows for panels.

**What changes did you make? (Give an overview)**
* Add a popup window button to the `Panel`.
* Gave `Panel` a new attribute `popup-url`, which when specified, will be the URL that the popup window button navigates to.

**Provide a demo:**
![popup](https://user-images.githubusercontent.com/3168908/40292548-92e2faea-5cfe-11e8-95b0-cd70bf938275.gif)

**Is there anything you'd like reviewers to focus on?**
The description of the new button in the documentation.

**Testing instructions:**
1. Navigate to the panel that has the popup window button enabled.
1. Click on the button. A new window should appear.