### PR TITLE
Add searchbar component

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,16 @@ module.exports = {
     'max-len': ['error', { 'code': 110 }],
     'operator-linebreak': ['error', 'before'],
     'quote-props': 'off',
+    'vue/html-self-closing': [
+      'error',
+      {
+        'html': {
+          'void': 'always',
+          'normal': 'never',
+        },
+      },
+    ],
+    'vue/max-attributes-per-line': ['error', { 'singleline': 2 }],
     'vue/order-in-components': 'off',
   },
 };

--- a/docs/bodyDocs.vue
+++ b/docs/bodyDocs.vue
@@ -30,6 +30,7 @@
         <tooltip-docs></tooltip-docs>
         <popover-docs></popover-docs>
         <trigger-docs></trigger-docs>
+        <searchbar-docs></searchbar-docs>
       </div>
       <div class="col-md-3">
         <affix-sidebar></affix-sidebar>
@@ -71,6 +72,7 @@ import selectDocs from './example/selectDocs.vue'
 import tabsDocs from './example/tabsDocs.vue'
 import tooltipDocs from './example/tooltipDocs.vue'
 import imageDocs from './example/imageDocs.vue'
+import searchbarDocs from './example/searchbarDocs.vue'
 import tipBoxDocs from './example/tipBoxDocs.vue'
 import triggerDocs from './example/triggerDocs.vue'
 
@@ -90,6 +92,7 @@ export default {
     questionDocs,
     popoverDocs,
     retrieverDocs,
+    searchbarDocs,
     selectDocs,
     tabsDocs,
     tooltipDocs,

--- a/docs/example/searchbarDocs.vue
+++ b/docs/example/searchbarDocs.vue
@@ -1,0 +1,174 @@
+<template>
+  <doc-section id="searchbarDocs" name="Searchbar">
+    <div class="bs-example">
+      <searchbar
+        :data="searchData"
+        :on-hit="consoleCallback"/>
+    </div>
+    <doc-code language="markup">
+      <searchbar
+        :data="searchData"
+        :on-hit="consoleCallback"/>
+    </doc-code>
+    <doc-code language="javascript">
+      <!-- eslint-disable vue/html-indent, vue/no-parsing-error, vue/valid-v-html -->
+      new Vue {
+        components: {
+          searchbar
+        },
+        data() {
+          return {
+            searchData: [
+              {
+                'headings': {
+                  'normal-include': 'Normal include',
+                  'establishing-requirements': 'Establishing Requirements',
+                  'include-segment': 'Include segment',
+                  'dynamic-include': 'Dynamic include',
+                  'boilerplate-include': 'Boilerplate include',
+                  'nested-include': 'Nested include',
+                  'html-include': 'HTML include',
+                  'include-from-another-markbind-site': 'Include from another Markbind site',
+                  'feature-list': 'Feature list',
+                },
+                'keywords': 'k1, k2, k3',
+                'src': 'index.md',
+                'title': 'Hello World',
+              },
+              {
+                'headings': {
+                  'popover-initiated-by-trigger-honor-trigger-attribute':
+                    'popover initiated by trigger: honor trigger attribute',
+                  'support-multiple-inclusions-of-a-modal': 'Support multiple inclusions of a modal',
+                  'remove-extra-space-in-links': 'Remove extra space in links',
+                },
+                'keywords': 'k4, k5, k6',
+                'src': 'bugs/index.md',
+                'title': 'Open Bugs',
+              },
+              {
+                'headings': {
+                  'feature-list': 'Feature list',
+                },
+                'keywords': 'k7, k8, k9',
+                'src': 'sub_site/index.md',
+                'title': 'Feature Page',
+              },
+            ],
+          };
+        },
+        methods: {
+          consoleCallback(match) {
+            const page = `/${match.src.replace('.md', '.html')}`;
+            const anchor = match.heading ? `#${match.heading.id}` : '';
+            console.log(`${page}${anchor}`);
+          },
+        },
+      }
+      <!-- eslint-enable vue/html-indent, vue/no-parsing-error, vue/valid-v-html -->
+    </doc-code>
+    <doc-table>
+      <div>
+        <p>data</p>
+        <p><code>Array</code></p>
+        <p></p>
+        <p>The local data source for suggestions. Expected to be a primitive array.</p>
+      </div>
+      <div>
+        <p>on-hit</p>
+        <p><code>Function</code></p>
+        <p></p>
+        <p>A callback function when you click or hit return on an item.</p>
+      </div>
+      <div>
+        <p>template</p>
+        <p><code>String</code></p>
+        <p>See below.</p>
+        <p>Used to render suggestion.</p>
+      </div>
+      <div>
+        <p>template-name</p>
+        <p><code>String</code></p>
+        <p></p>
+        <p>Used to specify name of the template.</p>
+      </div>
+    </doc-table>
+    Default template:
+    <doc-code>
+      <!-- eslint-disable vue/no-parsing-error, vue/valid-v-html -->
+      <span v-html="item.title | highlight value"></span>
+      <br v-if="item.keywords" />
+      <small v-if="item.keywords" v-html="item.keywords | highlight value"></small>
+      <br v-if="item.heading" />
+      <small v-if="item.heading" v-html="item.heading.text | highlight value"></small>
+      <!-- eslint-enable vue/no-parsing-error, vue/valid-v-html -->
+    </doc-code>
+  </doc-section>
+</template>
+
+<script>
+// eslint-disable-next-line import/no-unresolved
+import searchbar from 'src/Searchbar.vue';
+
+import docCode from './docCode.vue';
+import docSection from './docSection.vue';
+import docTable from './docTable.vue';
+
+export default {
+  components: {
+    docCode,
+    docSection,
+    docTable,
+    searchbar,
+  },
+  data() {
+    return {
+      searchData: [
+        {
+          'headings': {
+            'normal-include': 'Normal include',
+            'establishing-requirements': 'Establishing Requirements',
+            'include-segment': 'Include segment',
+            'dynamic-include': 'Dynamic include',
+            'boilerplate-include': 'Boilerplate include',
+            'nested-include': 'Nested include',
+            'html-include': 'HTML include',
+            'include-from-another-markbind-site': 'Include from another Markbind site',
+            'feature-list': 'Feature list',
+          },
+          'keywords': 'k1, k2, k3',
+          'src': 'index.md',
+          'title': 'Hello World',
+        },
+        {
+          'headings': {
+            'popover-initiated-by-trigger-honor-trigger-attribute':
+              'popover initiated by trigger: honor trigger attribute',
+            'support-multiple-inclusions-of-a-modal': 'Support multiple inclusions of a modal',
+            'remove-extra-space-in-links': 'Remove extra space in links',
+          },
+          'keywords': 'k4, k5, k6',
+          'src': 'bugs/index.md',
+          'title': 'Open Bugs',
+        },
+        {
+          'headings': {
+            'feature-list': 'Feature list',
+          },
+          'keywords': 'k7, k8, k9',
+          'src': 'sub_site/index.md',
+          'title': 'Feature Page',
+        },
+      ],
+    };
+  },
+  methods: {
+    consoleCallback(match) {
+      const page = `/${match.src.replace('.md', '.html')}`;
+      const anchor = match.heading ? `#${match.heading.id}` : '';
+      // eslint-disable-next-line no-console
+      console.log(`${page}${anchor}`);
+    },
+  },
+};
+</script>

--- a/src/Searchbar.vue
+++ b/src/Searchbar.vue
@@ -1,0 +1,60 @@
+<script>
+import typeahead from './Typeahead.vue';
+
+export default {
+  extends: typeahead,
+  ready() {
+    this.$els.dropdown.classList.add('search-dropdown-menu');
+  },
+  partials: {
+    default: '<span v-html="item.title | highlight value"></span>'
+      + '<br v-if="item.keywords" />'
+      + '<small v-if="item.keywords" v-html="item.keywords | highlight value"></small>'
+      + '<br v-if="item.heading" />'
+      + '<small v-if="item.heading" v-html="item.heading.text | highlight value"></small>',
+  },
+  computed: {
+    primitiveData() {
+      if (!this.data) {
+        return undefined;
+      }
+      const matches = [];
+      const regex = new RegExp(this.value, 'i');
+      this.data.forEach((entry) => {
+        const { headings, src, title } = entry;
+        const keywords = entry.keywords || '';
+        let hasMatchingHeading = false;
+        Object.entries(headings).forEach(([id, text]) => {
+          if (regex.test(text)) {
+            hasMatchingHeading = true;
+            matches.push({
+              heading: { id, text },
+              keywords,
+              src,
+              title,
+            });
+          }
+        });
+        if (!hasMatchingHeading) {
+          if (regex.test(title) || regex.test(keywords)) {
+            matches.push(entry);
+          }
+        }
+      });
+      return matches;
+    },
+  },
+  filters: {
+    highlight(value, phrase) {
+      return value.replace(new RegExp(`(${phrase})`, 'gi'), '<mark>$1</mark>');
+    },
+  },
+};
+</script>
+
+<style>
+.search-dropdown-menu {
+  max-height: 30em;
+  overflow-y: scroll;
+}
+</style>

--- a/src/index.js
+++ b/src/index.js
@@ -4,25 +4,26 @@ import alert from './Alert.vue'
 import aside from './Aside.vue'
 import carousel from './Carousel.vue'
 import checkbox from './Checkbox.vue'
+import closeable from './directives/Closeable'
 import dropdown from './Dropdown.vue'
 import dynamicPanel from './DynamicPanel.vue'
 import input from './Input.vue'
 import modal from './Modal.vue'
 import morph from './Morph.vue'
 import navbar from './Navbar.vue'
-import question from './Question.vue'
 import panel from './Panel.vue'
+import pic from './Pic.vue'
 import popover from './Popover.vue'
+import question from './Question.vue'
 import retriever from './Retriever.vue'
+import searchbar from './Searchbar.vue'
 import select from './Select.vue'
+import showModal from './directives/ShowModal'
 import tab from './Tab.vue'
 import tabGroup from './TabGroup.vue'
 import tabset from './Tabset.vue'
-import tooltip from './Tooltip.vue'
-import closeable from './directives/Closeable'
-import showModal from './directives/ShowModal'
-import pic from './Pic.vue'
 import tipBox from './TipBox.vue'
+import tooltip from './Tooltip.vue'
 import trigger from './trigger.vue'
 import typeahead from './Typeahead.vue'
 
@@ -37,19 +38,20 @@ const components = {
   modal,
   morph,
   navbar,
-  question,
   panel,
+  pic,
   popover,
+  question,
   retriever,
+  searchbar,
   select,
   tab,
   tabGroup,
   tabs: tabset,
   tipBox,
   tooltip,
-  pic,
   trigger,
-  typeahead
+  typeahead,
 }
 
 const directives = {


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [] Documentation update
• [ ] Bug fix
• [ ] New feature
• [x] Enhancement to an existing feature
• [ ] Other, please explain:

Related MarkBind/markbind#162, MarkBind/markbind#204

What is the rationale for this request?
highlighting and extracting the search result helps users to identify the results they want easily,
searching for headings and jump to the headings on click helpers users to go to website sections easily.

What changes did you make? (Give an overview)
highlightAndExtract function will extract the matching results then highlight the phrases.
for jumping to a specific heading, we have one entry for each heading(suggested by Prof Damith).
Thus, Instead of processing on a single string that combines title, keywords and headings, we match headings first, then title and keywords.

Testing instructions:

1. in vue-strap npm run build

2. copy paste vue-strap.min.js to markbind

3. After cloning the CS3281 website, go to common/header.md, and replace the use of typeahead with searchbar

4. test on 3281 website