### PR TITLE
Delay loading data until search keywords is non-trivial

### DIFF
--- a/src/Searchbar.vue
+++ b/src/Searchbar.vue
@@ -15,6 +15,9 @@ export default {
   },
   computed: {
     primitiveData() {
+      if (this.value.length < 2) {
+        return [];
+      }
       if (!this.data) {
         return undefined;
       }


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [X] Enhancement to an existing feature
• [ ] Other, please explain:

Resolves MarkBind/markbind#256

What is the rationale for this request?
Currently search results start loading as soon as the user types one char.this PRmight alleviate the initial lag the user experience when searching

What changes did you make? (Give an overview)
early return in primitiveData if the input is less than 3.

Testing instructions:
1.run npm run docs
2.can try key in keywords