### PR TITLE
Auto-scroll the search result list to keep the selection in view

### DIFF
--- a/src/Searchbar.vue
+++ b/src/Searchbar.vue
@@ -91,6 +91,32 @@ export default {
       return highlightedValue;
     },
   },
+  methods: {
+    down() {
+      if (this.current < this.items.length - 1) {
+        this.current += 1;
+        this.scrollListView();
+      }
+    },
+    up() {
+      if (this.current > 0) {
+        this.current -= 1;
+        this.scrollListView();
+      }
+    },
+    scrollListView() {
+      const { dropdown } = this.$els;
+      const currentEntry = dropdown.children[this.current];
+      const upperBound = dropdown.scrollTop;
+      const lowerBound = upperBound + dropdown.clientHeight;
+      const currentEntryOffsetBottom = currentEntry.offsetTop + currentEntry.offsetHeight;
+      if (currentEntry.offsetTop < upperBound) {
+        dropdown.scrollTop = currentEntry.offsetTop;
+      } else if (currentEntryOffsetBottom > lowerBound) {
+        dropdown.scrollTop = currentEntryOffsetBottom - dropdown.clientHeight;
+      }
+    },
+  },
 };
 </script>
 


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [ ] Documentation update
• [ ] Bug fix
• [ ] New feature
• [X] Enhancement to an existing feature
• [ ] Other, please explain:

Resolves MarkBind/markbind#258

What is the rationale for this request?
Currently, when the user navigates down the result list using the down arrow, the selection goes out of the view port of the list. The dropdown should auto-scroll to the entry

What changes did you make? (Give an overview)
update up and down event handler to scroll to current item

Testing instructions:
1. deployed website: https://nusjzx.github.io/website-base/