### PR TITLE
Support modals within modals

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -135,6 +135,7 @@ export default {
       if (id === this.id) {
         el.setTriggerBy(this)
       }
+      return true;
     }
   },
   methods: {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Fix https://github.com/MarkBind/markbind/issues/105

**What is the rationale for this request?**
User may want to put modals within modals.

**What changes did you make? (Give an overview)**
propagate the broadcasting of `trigger:bind` event, so that modal inside modal can be registered.


**Testing instructions:**
1. npm run build
2. copy paste `vue-strap.min.js`
3. `markbind init`
4. write following file in the folder
index.md 
```
<trigger for="modal:modal-example" trigger="click">modal windows</trigger>

<modal title="Modal Example" id="modal:modal-example">
  <include src="foo.md"/>
</modal>
```
foo.md:
```
Additional info
<trigger for="modal:second" trigger="click">second modal</trigger>

<modal title="Modal Second" id="modal:second">
  Second
</modal>
```