### PR TITLE
Migrate dropdown to Vue 2.0

### DIFF
--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -28,7 +28,7 @@
   </div>
 </template>
 <script>
-import {coerce} from './utils/utils.js'
+import {toBoolean} from './utils/utils.js'
 import $ from './utils/NodeList.js'
 
 export default {
@@ -36,13 +36,11 @@ export default {
     show: {
       twoWay: true,
       type: Boolean,
-      coerce: coerce.boolean,
       default: false
     },
     'class': null,
     disabled: {
       type: Boolean,
-      coerce: coerce.boolean,
       default: false
     },
     text: {
@@ -59,12 +57,18 @@ export default {
       return `btn-${this.type}`;
     },
     classes () {
-      return [{open: this.show, disabled: this.disabled}, this.class, this.isLi ? 'dropdown' : this.inInput ? 'input-group-btn': 'btn-group']
+      return [{open: this.showBool, disabled: this.disabledBool}, this.class, this.isLi ? 'dropdown' : this.inInput ? 'input-group-btn': 'btn-group']
+    },
+    disabledBool() {
+      return toBoolean(this.disabled);
     },
     inInput () { return this.$parent._input },
     isLi () { return this.$parent._navbar || this.$parent.menu || this.$parent._tabset },
     menu () {
       return !this.$parent || this.$parent.navbar
+    },
+    showBool() {
+      return toBoolean(this.show);
     },
     submenu () {
       return this.$parent && (this.$parent.menu || this.$parent.submenu)
@@ -93,8 +97,8 @@ export default {
     $el.onBlur((e) => { this.show = false }, false)
     $el.findChildren('a,button.dropdown-toggle').on('click', e => {
       e.preventDefault()
-      if (this.disabled) { return false }
-      this.show = !this.show
+      if (this.disabledBool) { return false }
+      this.show = !this.showBool
       return false
     })
     $el.findChildren('ul').on('click', 'li>a', e => { this.show = false })

--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -34,7 +34,6 @@ import $ from './utils/NodeList.js'
 export default {
   props: {
     show: {
-      twoWay: true,
       type: Boolean,
       default: false
     },

--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -86,7 +86,7 @@ export default {
       }
     }
   },
-  ready () {
+  mounted () {
     const $el = $(this.$refs.dropdown)
     $el.onBlur((e) => { this.show = false }, false)
     $el.findChildren('a,button.dropdown-toggle').on('click', e => {

--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -1,5 +1,5 @@
 <template>
-  <li v-if="isLi" v-el:dropdown :class="classes">
+  <li v-if="isLi" ref="dropdown" :class="classes">
     <slot name="button">
       <a class="dropdown-toggle" role="button" :class="{disabled: disabled}" @keyup.esc="show = false" v-html="text">
         <span class="caret"></span>
@@ -11,7 +11,7 @@
       </ul>
     </slot>
   </li>
-  <div v-else v-el:dropdown :class="classes">
+  <div v-else ref="dropdown" :class="classes">
     <slot name="before"></slot>
     <slot name="button">
       <button type="button" class="btn dropdown-toggle" :class="btnType" @keyup.esc="show = false" :disabled="disabled" v-html="text">

--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -1,7 +1,8 @@
 <template>
   <li v-if="isLi" ref="dropdown" :class="classes">
     <slot name="button">
-      <a class="dropdown-toggle" role="button" :class="{disabled: disabled}" @keyup.esc="show = false" v-html="text">
+      <a class="dropdown-toggle" role="button" :class="{disabled: disabled}" @keyup.esc="show = false">
+        {{ text }}
         <span class="caret"></span>
       </a>
     </slot>
@@ -14,7 +15,8 @@
   <div v-else ref="dropdown" :class="classes">
     <slot name="before"></slot>
     <slot name="button">
-      <button type="button" class="btn dropdown-toggle" :class="btnType" @keyup.esc="show = false" :disabled="disabled" v-html="text">
+      <button type="button" class="btn dropdown-toggle" :class="btnType" @keyup.esc="show = false" :disabled="disabled">
+        {{ text }}
         <span class="caret"></span>
       </button>
     </slot>

--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -87,7 +87,7 @@ export default {
     }
   },
   ready () {
-    const $el = $(this.$els.dropdown)
+    const $el = $(this.$refs.dropdown)
     $el.onBlur((e) => { this.show = false }, false)
     $el.findChildren('a,button.dropdown-toggle').on('click', e => {
       e.preventDefault()
@@ -98,7 +98,7 @@ export default {
     $el.findChildren('ul').on('click', 'li>a', e => { this.show = false })
   },
   beforeDestroy () {
-    const $el = $(this.$els.dropdown)
+    const $el = $(this.$refs.dropdown)
     $el.offBlur()
     $el.findChildren('a,button').off()
     $el.findChildren('ul').off()


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Other, please explain: Migration

**What is the rationale for this request?**
Migration

**What changes did you make? (Give an overview)**
Migration

**Provide some example code that this change will affect:**
NIL

**Is there anything you'd like reviewers to focus on?**
NIL

**Testing instructions:**
1. [Build the newly migrated dropdown component and deploy it to MarkBind](https://gist.github.com/yamgent/5674eed3822e0725f0347aa121bb0967).
1. On an empty folder, do `markbind init`.
1. Insert the following code to `index.md`:
```html
<menu>
  <dropdown text="Dropdown Normal">
    <li><a href="#">Normal 1</a></li>
    <li><a href="#">Normal 2</a></li>
  </dropdown>

  <dropdown text="Dropdown Disabled" disabled>
    <li><a href="#">Disabled 1</a></li>
    <li><a href="#">Disabled 2</a></li>
  </dropdown>

  <dropdown text="Dropdown with Type" type="danger">
    <li><a href="#">Danger 1</a></li>
    <li><a href="#">Danger 2</a></li>
  </dropdown>

  <dropdown text="Dropdown Show" show>
    <li><a href="#">Automatically shown 1</a></li>
    <li><a href="#">Automatically shown 2</a></li>
  </dropdown>

  <dropdown>
    <li><a href="#">No text 1</a></li>
    <li><a href="#">No text 2</a></li>
  </dropdown>

  <dropdown text="No Items Dropdown">
  </dropdown>
</menu>
```
4. Do `markbind serve`.
5. Ensure that the dropdown components are rendered and behave as expected just like in Vue 1.0.