### PR TITLE
Migrate Question component

### DIFF
--- a/docs/example/questionDocs.vue
+++ b/docs/example/questionDocs.vue
@@ -4,7 +4,7 @@
             Question component consists of a question body, a hint and an answer.
         </h4>
         <div class="bs-example">
-            <Question>
+            <question>
                 Body
                 <div slot="hint">
                     Hint
@@ -12,10 +12,10 @@
                 <div slot="answer">
                     Answer
                 </div>
-            </Question>
+            </question>
         </div>
         <doc-code language="markup">
-            <Question>
+            <question>
                 Body
                 <div slot="hint">
                     Hint
@@ -23,83 +23,44 @@
                 <div slot="answer">
                     Answer
                 </div>
-            </Question>
+            </question>
         </doc-code>
         <br>
         <h4>If no Hint slot is specified, it will not show:</h4>
         <div class="bs-example">
-            <Question>
+            <question>
                 Body
                 <div slot="answer">
                     Answer
                 </div>
-            </Question>
+            </question>
         </div>
         <h4>If no Answer slot is specified, it will not show:</h4>
         <div class="bs-example">
-            <Question>
+            <question>
                 Body
-            </Question>
+            </question>
         </div>
         <doc-code language="markup">
             If no Hint slot is specified, it will not show:
-            <Question>
+            <question>
                 Body
                 <div slot="answer">
                     Answer
                 </div>
-            </Question>
+            </question>
 
             If no Answer slot is specified, it will not show:
-            <Question>
+            <question>
                 Body
-            </Question>
-        </doc-code>
-        <br>
-        <h4>
-            Question component can be used with Morph component to create an inline question group.
-        </h4>
-        <p>
-            It can also be stored in a remote file and loaded when it is to be shown.
-        </p>
-        <div class="bs-example">
-            <morph title="Review question">
-                <Question>
-                    Body
-                    <div slot="hint">
-                        Hint
-                    </div>
-                    <div slot="answer">
-                        Answer
-                    </div>
-                </Question>
-            </morph>
-            <morph title="Remote question" src="docs/question.html"></morph>
-        </div>
-        <doc-code language="markup">
-            Use inline with Morph
-            <morph title="Review question">
-                <Question>
-                    Body
-                    <div slot="hint">
-                        Hint
-                    </div>
-                    <div slot="answer">
-                        Answer
-                    </div>
-                </Question>
-            </morph>
-
-            Use inline with Morph dynamic loading
-            <morph title="Remote question" src="docs/question.html">
-            </morph>
+            </question>
         </doc-code>
         <br>
         <h4>
             Use <code>has-input</code> attribute to add an input box for users to enter their answer.
         </h4>
         <div class="bs-example">
-            <Question has-input>
+            <question has-input>
                 Body
                 <div slot="hint">
                     Hint
@@ -107,10 +68,10 @@
                 <div slot="answer">
                     Answer
                 </div>
-            </Question>
+            </question>
         </div>
         <doc-code language="markup">
-            <Question has-input>
+            <question has-input>
                 Body
                 <div slot="hint">
                     Hint
@@ -118,7 +79,46 @@
                 <div slot="answer">
                     Answer
                 </div>
-            </Question>
+            </question>
+        </doc-code>
+        <br>
+        <h4>
+            Question component can be used with Panel component to create an inline question group.
+        </h4>
+        <p>
+            It can also be stored in a remote file and loaded when it is to be shown.
+        </p>
+        <div class="bs-example">
+            <panel header="Review question" minimized>
+                <question>
+                    Body
+                    <div slot="hint">
+                        Hint
+                    </div>
+                    <div slot="answer">
+                        Answer
+                    </div>
+                </question>
+            </panel>
+            <panel header="Remote question" src="docs/question.html" minimized></panel>
+        </div>
+        <doc-code language="markup">
+            Use inline with Panel
+            <panel header="Review question" minimized>
+                <question>
+                    Body
+                    <div slot="hint">
+                        Hint
+                    </div>
+                    <div slot="answer">
+                        Answer
+                    </div>
+                </question>
+            </panel>
+
+            Use inline with Panel dynamic loading
+            <panel header="Remote question" src="docs/question.html" minimized>
+            </panel>
         </doc-code>
         <doc-table>
         </doc-table>
@@ -130,7 +130,7 @@
   import docTable from './docTable.vue'
   import docCode from './docCode.vue'
   import question from 'src/Question.vue'
-  import morph from 'src/Morph.vue'
+  import panel from 'src/Panel.vue'
 
   export default {
     components: {
@@ -138,7 +138,7 @@
       docTable,
       docCode,
       question,
-      morph
+      panel
     },
     created() {
       this.$on('retriever:fetched', function (el) {

--- a/src/Question.vue
+++ b/src/Question.vue
@@ -3,53 +3,70 @@
         <div class="body-wrapper">
             <!-- Default slot is question body -->
             <slot></slot>
-            <div v-if="hasInput" class="textarea-container">
+            <div v-if="hasInputBool" class="textarea-container">
                 <textarea class="form-control question-input" rows="3" placeholder="write your answer here..."></textarea>
             </div>
         </div>
-        <accordion>
-            <panel v-show="hasHintSlot" header="Hint" expandable no-close>
-                <slot name="hint">
-                    No hint is available for this question.
-                </slot>
-            </panel>
-            <panel v-show="hasAnswerSlot" header="Answer" expandable no-close>
-                <slot name="answer"></slot>
-            </panel>
-        </accordion>
+        <panel v-show="hasHintSlot" header="Hint" expandable no-close>
+            <template v-if="isEmptyHint">
+                No hint is available for this question.
+            </template>
+            <template v-else>
+                <div ref="hintWrapper">
+                    <slot name="hint"></slot>
+                </div>
+            </template>
+        </panel>
+        <panel v-show="hasAnswerSlot" header="Answer" expandable no-close>
+            <template v-if="isEmptyAnswer">
+                No answer is provided for this question.
+            </template>
+            <template v-else>
+                <div ref="answerWrapper">
+                    <slot name="answer"></slot>
+                </div>
+            </template>
+        </panel>
     </div>
 </template>
 
 <script>
-  import {coerce} from './utils/utils.js'
-  import morph from './Morph.vue'
-  import accordion from './Accordion.vue'
+  import {toBoolean} from './utils/utils.js'
   import panel from './Panel.vue'
 
   export default {
     components: {
       panel,
-      morph,
-      accordion
     },
     props: {
       hasInput: {
         type: Boolean,
-        coerce: coerce.boolean,
         default: false
       }
+    },
+    computed: {
+      // Vue 2.0 coerce migration
+      hasInputBool () {
+        return toBoolean(this.hasInput);
+      }
+      // Vue 2.0 coerce migration end
     },
     data () {
       return {
         hasAnswerSlot: true,
-        hasHintSlot: true
+        hasHintSlot: true,
+        isEmptyAnswer: false,
+        isEmptyHint: false
       }
     },
-    attached() {
-      let hasAnswerSlot = !!this.$el.querySelector('[slot="answer"]');
-      this.hasAnswerSlot = hasAnswerSlot
-      let hasHintSlot = !!this.$el.querySelector('[slot="hint"]');
-      this.hasHintSlot = hasHintSlot
+    mounted() {
+      this.$nextTick(function() {
+        const emptyDiv = '<div></div>';
+        this.hasAnswerSlot = !!this.$slots.answer;
+        this.hasHintSlot = !!this.$slots.hint;
+        this.isEmptyAnswer = this.$refs.answerWrapper.innerHTML === emptyDiv;
+        this.isEmptyHint = this.$refs.hintWrapper.innerHTML === emptyDiv;
+      })
     }
   }
 </script>


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Other, migration
<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of MarkBind/markbind#266

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial should add a page or unit test for regression testing.
    - Feature PR must add a page to the user guide for demo.
    - Enhancement PR should update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

What changes did you make? (Give an overview)

**Note:** This PR is forked from `migrate-panel` branch as it is dependent on it, **PR has been rebased**

Global changes |
--- |
Change `v-el` / `v-ref` to **ref** |
Refactor `coerce` in `props` |
`attached()` / `ready()` to **mounted()** with **this.$nextTick()**

Specific changes |
--- |
Removed `Accordion` and `Morph` component usage as they are deprecated |
Add wrapper div for `hint` and `answer` slots to support insertion of **default values** |
Remove references of `Morph` in questionDocs (replaced by Panel) and re-arranged sections |  

Testing instructions:
1. Download [QuestionTest.zip](https://github.com/MarkBind/vue-strap/files/2121895/QuestionTest.zip)
2. Extract and run `markbind serve` within folder (after copy pasting updated vue.min.js etc)
3. Test provided question components 