### PR TITLE
Migrate Panel to Bootstrap 4.1.x

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -24,9 +24,9 @@
                 </div>
                 <div class="button-wrapper">
                     <slot name="button">
-                        <panel-switch v-show="canCollapse && !noSwitchBool && !showCaret" v-bind:is-open="localExpanded"
+                        <panel-switch v-show="canCollapse && !noSwitchBool && !showCaret" :is-open="localExpanded"
                                       @click.native.stop.prevent="expand()"
-                                      @is-open-event="retrieveOnOpen" v-bind:is-light-bg="isLightBg"></panel-switch>
+                                      @is-open-event="retrieveOnOpen" :is-light-bg="isLightBg"></panel-switch>
                         <button type="button" :class="['close-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
                                 v-show="!isSeamless ? (!noCloseBool) : onHeaderHover"
                                 @click.stop="close()">
@@ -47,7 +47,7 @@
                 <div class="card-body">
                     <slot></slot>
                     <retriever v-if="isDynamic" ref="retriever" :src="src" :fragment="fragment" delay></retriever>
-                    <panel-switch v-show="canCollapse && bottomSwitchBool" v-bind:is-open="localExpanded"
+                    <panel-switch v-show="canCollapse && bottomSwitchBool" :is-open="localExpanded"
                                   @click.native.stop.prevent="collapseThenScrollIntoViewIfNeeded()"
                                   @is-open-event="retrieveOnOpen"></panel-switch>
                 </div>

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -164,29 +164,30 @@
         return this.type === 'seamless';
       },
       btnType () {
-        if (this.isSeamless) {
+        if (this.isSeamless || this.type === 'light') {
           return 'btn-outline-secondary';
-        } else {
-          return 'btn-outline-' + (this.type || 'secondary');
         }
+        return 'btn-outline-' + (this.type || 'secondary');
       },
       borderType () {
         if (this.isSeamless) {
           return 'border-0';
         } else if (this.type) {
+          if (this.type === 'light') {
+            return ''; // Bootstrap 4.x light border is almost invisible on a white page
+          }
           return 'border-' + this.type;
         }
-        else '';
+        return '';
       },
       cardType () {
         if (this.isSeamless) {
           return 'bg-white';
-        } else {
-          return 'bg-' + (this.type || 'light');
         }
+        return 'bg-' + (this.type || 'light');
       },
-      isLightBg() {
-        return this.cardType === 'bg-light' || this.cardType === 'bg-white';
+      isLightBg () {
+        return this.cardType === 'bg-light' || this.cardType === 'bg-white' || this.cardType === 'bg-warning';
       },
       headerContent () {
         return md.render(this.header);

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -3,7 +3,7 @@
         <div class="morph" v-show="localMinimized">
             <button :class="['morph-display-wrapper', 'btn', btnType, 'card-title']" @click="open()">
                 <template v-if="altContent">
-                    <div  v-html="altContent"></div>
+                    <div v-html="altContent"></div>
                 </template>
                 <template v-else>
                     <slot name="header">
@@ -13,8 +13,8 @@
             </button>
         </div>
         <div :class="['card', {'expandable-card': isExpandableCard}, borderType]" v-show="!localMinimized">
-            <div :class="['card-header',{'accordion-toggle':canCollapse}, cardType, borderType]"
-                 @click.prevent.stop="canCollapse && toggle()"
+            <div :class="['card-header',{'header-toggle':isExpandableCard}, cardType, borderType]"
+                 @click.prevent.stop="isExpandableCard && toggle()"
                  @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
                 <div class="header-wrapper">
                     <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-show="showCaret"></span>
@@ -24,7 +24,7 @@
                 </div>
                 <div class="button-wrapper">
                     <slot name="button">
-                        <panel-switch v-show="canCollapse && !noSwitchBool && !showCaret" :is-open="localExpanded"
+                        <panel-switch v-show="isExpandableCard && !noSwitchBool && !showCaret" :is-open="localExpanded"
                                       @click.native.stop.prevent="expand()"
                                       @is-open-event="retrieveOnOpen" :is-light-bg="isLightBg"></panel-switch>
                         <button type="button" :class="['close-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
@@ -47,7 +47,7 @@
                 <div class="card-body">
                     <slot></slot>
                     <retriever v-if="isDynamic" ref="retriever" :src="src" :fragment="fragment" delay></retriever>
-                    <panel-switch v-show="canCollapse && bottomSwitchBool" :is-open="localExpanded"
+                    <panel-switch v-show="isExpandableCard && bottomSwitchBool" :is-open="localExpanded"
                                   @click.native.stop.prevent="collapseThenScrollIntoViewIfNeeded()"
                                   @is-open-event="retrieveOnOpen"></panel-switch>
                 </div>
@@ -148,14 +148,8 @@
         return toBoolean(this.loadAll);
       },
       // Vue 2.0 coerce migration end
-      inAccordion () {
-        return this.$parent && this.$parent._isAccordion;
-      },
       isExpandableCard () {
         return this.expandableBool;
-      },
-      canCollapse () {
-        return this.inAccordion || this.expandableBool;
       },
       showCaret () {
         return this.isSeamless;
@@ -305,7 +299,7 @@
         width: 28%;
     }
 
-    .accordion-toggle {
+    .header-toggle {
         cursor: pointer;
     }
 

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -17,7 +17,7 @@
                  @click.prevent.stop="canCollapse && toggle()"
                  @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
                 <div class="header-wrapper">
-                    <span :class="['caret', {'caret-collapse': !localExpanded}]" v-show="showCaret"></span>
+                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-show="showCaret"></span>
                     <slot name="header">
                         <div :class="['card-title', cardType, {'text-white':!isLightBg}]" v-html="headerContent"></div>
                     </slot>
@@ -26,13 +26,13 @@
                     <slot name="button">
                         <panel-switch v-show="canCollapse && !noSwitchBool && !showCaret" v-bind:is-open="localExpanded"
                                       @click.native.stop.prevent="expand()"
-                                      @is-open-event="retrieveOnOpen"></panel-switch>
-                        <button type="button" class="close-button btn btn-default"
+                                      @is-open-event="retrieveOnOpen" v-bind:is-light-bg="isLightBg"></panel-switch>
+                        <button type="button" :class="['close-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
                                 v-show="!isSeamless ? (!noCloseBool) : onHeaderHover"
                                 @click.stop="close()">
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                         </button>
-                        <button type="button" class="popup-button btn btn-default"
+                        <button type="button" :class="['popup-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
                                 v-show="this.popupUrl !== null"
                                 @click.stop="openPopup()">
                             <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span>
@@ -60,7 +60,7 @@
 <script>
   import {getFragmentByHash, toBoolean, toNumber} from './utils/utils.js'
   import md from './utils/markdown.js'
-  import panelSwitch from './panelSwitch.vue'
+  import panelSwitch from './PanelSwitch.vue'
   import retriever from './Retriever.vue'
 
   export default {
@@ -319,13 +319,6 @@
 
     .card-seamless {
         padding: 0;
-    }
-
-    .caret.caret-collapse {
-        border-left: 4px dashed;
-        border-top: 4px solid transparent;
-        border-bottom: 4px solid transparent;
-        border-right: none;
     }
 
     .card.card-seamless {

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -346,6 +346,7 @@
     }
 
     .card-body > .collapse-button {
+        margin-bottom: 13px;
         margin-top: 5px;
         opacity: 0.2;
     }

--- a/src/PanelSwitch.vue
+++ b/src/PanelSwitch.vue
@@ -1,5 +1,5 @@
 <template>
-    <button type="button" class="collapse-button btn btn-default">
+    <button type="button" :class="['collapse-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']">
         <span :class="['glyphicon', {'glyphicon-menu-down': !isOpenBool, 'glyphicon-menu-up': isOpenBool}]"
               aria-hidden="true"></span>
     </button>
@@ -14,6 +14,10 @@
         type: Boolean,
         default: null
       },
+      isLightBg: {
+        type: Boolean,
+        default: true
+      }
     },
     computed: {
       isOpenBool () {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Other, migration

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Part of MarkBind/markbind#298

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial should add a page or unit test for regression testing.
    - Feature PR must add a page to the user guide for demo.
    - Enhancement PR should update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What changes did you make? (Give an overview)**
- Refactor `panel` tags into `card` tags, as `panel` is deprecated in Bootstrap 4
- Added additional computed properties and in-line template logic to account for syntax change in Bootstrap 4.
- Update button styling and made it dynamic W.R.T the panel's background colour.

Note |
--- |
`Glyphicons` are deprecated in Bootstrap 4. Therefore, buttons in Panel that use the icons are not rendered. The fix for this will be in a separate PR in the MarkBind repository. |
Even though `panel` tags have been refactored to `card`, the Vue component still uses `<panel>` as its name. The author can continue using `<panel>` without refactoring to `<card>` yet.
The user guide has to be updated as `default` type is not supported anymore. There are also other new types / styles available, such as `dark`.

**Testing instructions:**
1. Download [testPanelsV3.zip](https://github.com/MarkBind/vue-strap/files/2154208/testPanelsV3.zip)
1. Run `npm run build` and copy over the new `vue.min.js` and `vue-strap.min.js` to your MarkBind repository folder.
1. Run `markbind serve` in the `PanelTest` folder, provided above.
1. Test the provided panels.
