### PR TITLE
Migrate searchbar to Bootstrap 4.1.1

### DIFF
--- a/src/Searchbar.vue
+++ b/src/Searchbar.vue
@@ -3,9 +3,6 @@ import typeahead from './Typeahead.vue';
 
 export default {
   extends: typeahead,
-  mounted() {
-    this.$refs.dropdown.classList.add('search-dropdown-menu');
-  },
   computed: {
     primitiveData() {
       function getTotalMatches(searchTarget, regexes) {

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -1,7 +1,5 @@
 <template>
-  <div style="position: relative"
-       v-bind:class="{'open':showDropdown}"
-  >
+  <div style="position: relative">
     <input type="text" class="form-control"
       :placeholder="placeholder"
       autocomplete="off"
@@ -13,9 +11,9 @@
       @keydown.esc="reset"
       @blur="showDropdown = false"
     />
-    <ul class="dropdown-menu" ref="dropdown">
-      <li v-for="(item, index) in items" v-bind:class="{'active': isActive(index)}">
-        <a @mousedown.prevent="hit" @mousemove="setActive(index)">
+    <ul :class="{'show':showDropdown}" class="dropdown-menu search-dropdown-menu" ref="dropdown">
+      <li v-for="(item, index) in items" v-bind:class="{'table-active': isActive(index)}">
+        <a class="dropdown-item" @mousedown.prevent="hit" @mousemove="setActive(index)">
           <component v-bind:is="entryTemplate" :item="item" :value="value"></component>
         </a>
       </li>


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Other, please explain: Migration

Part of MarkBind/markbind#298.

What changes did you make? (Give an overview)
Migrate all CSS classes from Bootstrap 3 to Bootstrap 4
add "dropdown-item" class to dropdown item

Testing instructions:

Build vue-strap in this branch using `npm run build`.
Copy vue-strap.min.js from the dist folder in this repository, to the asset/js/ folder in markbind repository (NOTE: Activate the bootstrap-migration branch on markbind repository!)
Do `markbind init` on a new empty folder.
On its index.md, add this content:
```
<searchbar :data="searchData" placeholder="Search" :on-hit="searchCallback"></searchbar>
<h1 id ="h11">h11</h1>
<h2 id ="h21">h21</h2>
<h1 id ="h12">h12</h1>
<h2 id ="h22">h22</h2>
<h3 id ="h31">h31</h3>
<h3 id ="h32">h32</h3>
<h1 id ="h13">h13</h1>
<h2 id ="h23">h23</h2>
<h3 id ="h33">h33</h3>
<h3 id ="h34">h34</h3>
<h1 id ="h14">h14</h1>
<h2 id ="h24">h24</h2>

<h1 id ="h111">h11</h1>
<h2 id ="h211">h21</h2>
<h1 id ="h121">h12</h1>
<h2 id ="h221">h22</h2>
<h3 id ="h311">h31</h3>
<h3 id ="h321">h32</h3>
<h1 id ="h131">h13</h1>
<h2 id ="h231">h23</h2>
<h3 id ="h331">h33</h3>
<h3 id ="h341">h34</h3>
<h1 id ="h141">h14</h1>
<h2 id ="h241">h24</h2>
```