### PR TITLE
Migrate modal to Bootstrap 4.1.1

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -10,11 +10,11 @@
       <div class="modal-content">
         <slot name="modal-header">
           <div class="modal-header">
-            <button type="button" class="close" @click="close"><span>&times;</span></button>
             <h4 class="modal-title">
               <span name="title" v-html="titleRendered">
               </span>
             </h4>
+            <button type="button" class="close" @click="close"><span>&times;</span></button>
           </div>
         </slot>
           <div class="modal-body">
@@ -110,7 +110,7 @@ export default {
       if (val) {
         $(el).find('.modal-content').focus()
         el.style.display = 'block'
-        setTimeout(() => $(el).addClass('in'), 0)
+        setTimeout(() => $(el).addClass('show in'), 0)
         $(body).addClass('modal-open')
         if (scrollBarWidth !== 0) {
           body.style.paddingRight = scrollBarWidth + 'px'
@@ -123,7 +123,7 @@ export default {
       } else {
         body.style.paddingRight = null
         $(body).removeClass('modal-open')
-        $(el).removeClass('in').on('transitionend', () => {
+        $(el).removeClass('show in').on('transitionend', () => {
           $(el).off('click transitionend')
           el.style.display = 'none'
         })


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Other, please explain: Migration

Part of MarkBind/markbind#298.

What changes did you make? (Give an overview)


Testing instructions:

1.Build vue-strap in this branch using `npm run build`.
2. Copy vue-strap.min.js from the dist folder in this repository, to the asset/js/ folder in markbind repository (NOTE: Activate the bootstrap-migration branch on markbind repository!)
3. Do `markbind init` on a new empty folder.
4. On its index.md, add this content:
```
More about <trigger for="modal:trigger_id">trigger</trigger>.
<modal title="**Modal title** :rocket:" id="modal:trigger_id" effect="fade">
    ...
</modal>
<br>
This is the same <trigger for="modal:trigger_id">trigger</trigger> as last one.
```