### PR TITLE
Migrate popover & tooltip to Bootstrap 4.1.1

### DIFF
--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -4,13 +4,13 @@
     -->
     <transition :name="effect">
     <div ref="popover" v-if="show"
-      :class="['popover',placement]">
+      :class="['popover', popoverPlacementClass]">
       <div class="arrow" ref="arrow"></div>
-      <h3 class="popover-title" v-if="title" v-on:click="false">
+      <h3 class="popover-header" v-if="title" v-on:click="false">
         <slot name="title" v-if="hasTitleSlot"></slot>
         <span v-else v-html="titleRendered"></span>
       </h3>
-      <div class="popover-content" v-on:click="false">
+      <div class="popover-body" v-on:click="false">
         <slot name="content" v-if="hasContentSlot"></slot>
         <span v-else v-html="contentRendered"></span>
       </div>
@@ -40,6 +40,9 @@ export default {
     hasContentSlot () {
       return this.$slots.content;
     },
+    popoverPlacementClass() {
+      return `bs-popover-${this.placement}`;
+    }
   },
   mounted () {
     if (this.$refs.trigger) {

--- a/src/Tooltip.vue
+++ b/src/Tooltip.vue
@@ -4,9 +4,9 @@
     -->
     <transition :name="effect">
       <div ref="popover" v-if="show" style="display:block;"
-        :class="['tooltip',placement]"
+        :class="['tooltip', tooltipPlacementClass, 'show']"
       >
-        <div class="tooltip-arrow"></div>
+        <div class="arrow" ref="arrow"></div>
         <div class="tooltip-inner" v-on:click="false">
           <span name="content" v-html="contentRendered"></span>
        </div>
@@ -33,6 +33,11 @@ export default {
     placement: {
       type: String,
       default: 'top'
+    }
+  },
+  computed: {
+    tooltipPlacementClass ()  {
+      return `bs-tooltip-${this.placement}`;
     }
   },
   mounted () {

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -40,6 +40,7 @@ export default {
         top: 0,
         left: 0
       },
+      isPopover: false,
       show: false
     }
   },
@@ -72,6 +73,7 @@ export default {
       }
       setTimeout(() => {
         const popover = this.$refs.popover
+        this.isPopover = Array.some(popover.classList, classname => classname === 'popover');
         console.log(trigger.offsetTop)
         console.log(popover.offsetHeight)
         this.calculateOffset(trigger, popover)
@@ -100,10 +102,16 @@ export default {
         case 'top' :
           this.position.left = trigger.offsetLeft - popover.offsetWidth / 2 + trigger.offsetWidth / 2
           this.position.top = trigger.offsetTop - popover.offsetHeight
+          if (this.isPopover) {
+            this.position.top -= this.$refs.arrow.offsetHeight;
+          }
           break
         case 'left':
           this.position.left = trigger.offsetLeft - popover.offsetWidth
           this.position.top = trigger.offsetTop + trigger.offsetHeight / 2 - popover.offsetHeight / 2
+          if (this.isPopover) {
+            this.position.left -= this.$refs.arrow.offsetWidth;
+          }
           break
         case 'right':
           this.position.left = trigger.offsetLeft + trigger.offsetWidth
@@ -158,6 +166,15 @@ export default {
     adjustArrow (delta, dimension, isVertical) {
       this.$refs.arrow.style[isVertical ? 'left' : 'top'] = 50 * (1 - delta / dimension) + '%'
       this.$refs.arrow.style[isVertical ? 'top' : 'left'] = ''
+      let translateLeft = 0;
+      let translateTop = 0;
+      if (this.placement === 'left' || this.placement === 'right') {
+        translateTop = this.isPopover ? -75 : -50;
+      }
+      if (this.placement === 'top' || this.placement === 'bottom') {
+        translateLeft = this.isPopover ? -100 : -50;
+      }
+      this.$refs.arrow.style['transform'] = `translate(${translateLeft}%, ${translateTop}%)`;
     }
   },
   created () {


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Other, please explain: Migration

Part of MarkBind/markbind#298.

What changes did you make? (Give an overview)
migrate css class to Bootstrap 4.1.1

Testing instructions:

1.Build vue-strap in this branch using npm run build.
2. Copy vue-strap.min.js from the dist folder in this repository, to the asset/js/ folder in markbind repository (NOTE: Activate the bootstrap-migration branch on markbind repository!)
3. Do `markbind serve docs` 
4. check popover are rendered properly