### PR TITLE
Migrate tabs to Bootstrap 4.1.1

### DIFF
--- a/src/Tab.vue
+++ b/src/Tab.vue
@@ -82,7 +82,10 @@ export default {
     .tab-pane > hr {
         margin: 0;
     }
-    .fade-enter-active, .fade-leave-active {
+    .fade-enter-active {
       transition: opacity .5s;
+    }
+    .fade-leave-active {
+      transition: opacity 0s;
     }
 </style>

--- a/src/Tabset.vue
+++ b/src/Tabset.vue
@@ -1,13 +1,13 @@
 <template>
   <div>
     <!-- Nav tabs -->
-    <ul class="nav" :class="getNavStyleClass" role="tablist">
+    <ul class="nav nav-tabs" :class="getNavStyleClass" role="tablist">
       <template v-for="t in headers">
-        <li v-if="!t._tabgroup" :class="{active:t.active, disabled:t.disabledBool}" @click.prevent="select(t)">
-          <a href="#"><span v-html="t.headerRendered"></span></a>
+        <li v-if="!t._tabgroup" class="nav-item" @click.prevent="select(t)">
+          <a class="nav-link" :class="{active: t.active, disabled:t.disabledBool}" href="#"><span v-html="t.headerRendered"></span></a>
         </li>
-        <dropdown v-else :text="t.headerRendered" :class="{active:t.active}" :disabled="t.disabled">
-          <li v-for="tab in t.tabs" :class="{disabled:tab.disabled}"><a href="#" @click.prevent="select(tab)" v-html="tab.headerRendered"></a></li>
+        <dropdown v-else class="nav-link" :text="t.headerRendered" :class="{active:t.active}" :disabled="t.disabled">
+          <li v-for="tab in t.tabs"><a class="nav-link" :class="{disabled:tab.disabled}" href="#" @click.prevent="select(tab)" v-html="tab.headerRendered"></a></li>
         </dropdown>
       </template>
     </ul>


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Other, please explain: Migration

Part of MarkBind/markbind#298.

What changes did you make? (Give an overview)
1.migrate css class to Bootstrap 4.1.1
2.to fix fading effect: change fade-leave to 0s, otherwise, the previous tab content will stay there for 0.5s, make the new tab jump when fading-in 

Testing instructions:

1. need https://github.com/MarkBind/vue-strap/pull/54, can copy https://raw.githubusercontent.com/yamgent/vue-strap/38c146faa85400460a6a9b319e0d1456400b05d9/src/Dropdown.vue to replace Dropdown.vue
2.Build vue-strap in this branch using npm run build.
3. Copy vue-strap.min.js from the dist folder in this repository, to the asset/js/ folder in markbind repository (NOTE: Activate the bootstrap-migration branch on markbind repository!)
4. Do markbind serve docs
5. check tabs are rendered properly