### PR TITLE
Provide options for dropdown menu to be right-aligned

### DIFF
--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -47,6 +47,10 @@ export default {
     type: {
       type: String,
       default: 'light'
+    },
+    menuAlignRight: {
+      type: Boolean,
+      default: false
     }
   },
   computed: {
@@ -57,7 +61,7 @@ export default {
       return [{disabled: this.disabledBool}, this.class, this.isLi ? 'dropdown' : 'btn-group']
     },
     menuClasses() {
-      return [{show: this.showBool}];
+      return [{show: this.showBool}, {'dropdown-menu-right': this.menuAlignRight}];
     },
     disabledBool() {
       return toBoolean(this.disabled);

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -11,7 +11,7 @@
       @keydown.esc="reset"
       @blur="showDropdown = false"
     />
-    <ul :class="{'show':showDropdown}" class="dropdown-menu search-dropdown-menu" ref="dropdown">
+    <ul :class="dropdownMenuClasses" ref="dropdown">
       <li v-for="(item, index) in items" v-bind:class="{'table-active': isActive(index)}">
         <a class="dropdown-item" @mousedown.prevent="hit" @mousemove="setActive(index)">
           <component v-bind:is="entryTemplate" :item="item" :value="value"></component>
@@ -63,6 +63,10 @@ export default {
     delay: {
       type: Number,
       default: _DELAY_,
+    },
+    menuAlignRight: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -85,6 +89,10 @@ export default {
     },
     entryTemplate () {
       return 'typeaheadTemplate';
+    },
+    dropdownMenuClasses () {
+      return ['dropdown-menu', 'search-dropdown-menu', {show: this.showDropdown},
+        {'dropdown-menu-right': this.menuAlignRight}];
     }
   },
   methods: {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement

**What is the rationale for this request?**
The searchbar's dropdown menu can get cut off when the textbox is at the extreme right of the screen:

Old | New
--- | ---
<img src="https://user-images.githubusercontent.com/3168908/42305743-f8d552d4-805e-11e8-97af-88a143282ecd.png" /> | <img src="https://user-images.githubusercontent.com/3168908/42305747-fabfc836-805e-11e8-8979-e13914319324.png" />


**What changes did you make? (Give an overview)**
Provide a new option `menu-align-right` for both `Typeahead` and `Dropdown`. Specifying this option allows the dropdown menu to be right aligned.

**Provide some example code that this change will affect:**
NIL

**Is there anything you'd like reviewers to focus on?**
NIL

**Testing instructions:**
1. Run `npm run build` on this branch, then copy the newly minted `vue-strap.min.js` over to the MarkBind's repository's assets/js.
2. Create a new markbind website.
3. Modify `index.md` to include the following:

```markdown
## Searchbar
<searchbar :data="searchData" placeholder="Left aligned" :on-hit="searchCallback"></searchbar>

<searchbar :data="searchData" placeholder="Right aligned" :on-hit="searchCallback" menu-align-right></searchbar>

## Dropdown
<dropdown text="Left aligned">
  <li><a href="#" class="dropdown-item">Item 1</a></li>
  <li><a href="#" class="dropdown-item">Item 2</a></li>
</dropdown>

<dropdown text="Right aligned" menu-align-right>
  <li><a href="#" class="dropdown-item">Item 1</a></li>
  <li><a href="#" class="dropdown-item">Item 2</a></li>
</dropdown>

-- End of components. Fake headings below. --

## Fake headings

### Abc

### Def
```

4. Run `markbind serve`. Ensure that the `menu-align-right` are right aligned.