### PR TITLE
Add full dynamic behaviour for Panel contents

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -40,19 +40,36 @@
                     </slot>
                 </div>
             </div>
-            <div class="card-collapse"
-                 ref="panel"
-                 v-show="localExpanded"
-            >
-                <div class="card-body">
-                    <slot></slot>
-                    <retriever v-if="isDynamic" ref="retriever" :src="src" :fragment="fragment" delay></retriever>
-                    <panel-switch v-show="isExpandableCard && bottomSwitchBool" :is-open="localExpanded"
-                                  @click.native.stop.prevent="collapseThenScrollIntoViewIfNeeded()"
-                                  @is-open-event="retrieveOnOpen"></panel-switch>
+            <template v-if="dynamicBool">
+                <div class="card-collapse"
+                     ref="panel"
+                     v-if="localExpanded"
+                >
+                    <div class="card-body">
+                        <slot></slot>
+                        <retriever v-if="hasSrc" ref="retriever" :src="src" :fragment="fragment" delay></retriever>
+                        <panel-switch v-show="isExpandableCard && bottomSwitchBool" :is-open="localExpanded"
+                                      @click.native.stop.prevent="collapseThenScrollIntoViewIfNeeded()"
+                                      @is-open-event="retrieveOnOpen"></panel-switch>
+                    </div>
+                    <hr v-show="isSeamless" />
                 </div>
-                <hr v-show="isSeamless" />
-            </div>
+            </template>
+            <template v-else>
+                <div class="card-collapse"
+                     ref="panel"
+                     v-show="localExpanded"
+                >
+                    <div class="card-body">
+                        <slot></slot>
+                        <retriever v-if="hasSrc" ref="retriever" :src="src" :fragment="fragment" delay></retriever>
+                        <panel-switch v-show="isExpandableCard && bottomSwitchBool" :is-open="localExpanded"
+                                      @click.native.stop.prevent="collapseThenScrollIntoViewIfNeeded()"
+                                      @is-open-event="retrieveOnOpen"></panel-switch>
+                    </div>
+                    <hr v-show="isSeamless" />
+                </div>
+            </template>
         </div>
     </span>
 </template>
@@ -116,7 +133,7 @@
         type: Boolean,
         default: true
       },
-      loadAll: {
+      dynamic: {
         type: Boolean,
         default: false
       }
@@ -144,8 +161,8 @@
       bottomSwitchBool () {
         return toBoolean(this.bottomSwitch);
       },
-      loadAllBool () {
-        return toBoolean(this.loadAll);
+      dynamicBool () {
+        return toBoolean(this.dynamic);
       },
       // Vue 2.0 coerce migration end
       isExpandableCard () {
@@ -189,7 +206,7 @@
       altContent () {
         return this.alt && md.render(this.alt) || md.render(this.header);
       },
-      isDynamic () {
+      hasSrc () {
         return this.src && this.src.length > 0;
       },
       showCloseButton () {
@@ -238,14 +255,16 @@
         window.open(this.popupUrl);
       },
       retrieveOnOpen(el, isOpen) {
-        if (isOpen && this.isDynamic) {
+        if (isOpen && this.hasSrc) {
           this.$refs.retriever.fetch()
         }
       }
     },
     watch: {
       'localExpanded': function (val, oldVal) {
-        this.retrieveOnOpen(this, val);
+        this.$nextTick(function () {
+          this.retrieveOnOpen(this, val);
+        })
       },
     },
     created () {
@@ -264,7 +283,7 @@
     },
     mounted() {
       this.$nextTick(function () {
-        if (this.isDynamic && (this.expandedBool || this.loadAllBool)) {
+        if (this.hasSrc && (!this.dynamicBool || this.localExpanded)) {
           this.$refs.retriever.fetch()
         }
       })


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of MarkBind/markbind#307 

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
User would like to change the behaviour of having all Panel content dynamically rendered, not just for `src`.

**What changes did you make? (Give an overview)**
- Remove `loadAll` prop and references.
- Add `dynamic` prop and additional templates

Before<br>(bottom half of panel is rendered in HTML) |
--- |
![non-dynamic-panel](https://user-images.githubusercontent.com/31084833/42368760-7d5ff0a0-813a-11e8-805c-c66f0cdb9264.PNG) |

After<br>(bottom half not rendered until user expands the panel) |
--- |
![dynamic-panel](https://user-images.githubusercontent.com/31084833/42368808-9e5c80ac-813a-11e8-82b2-25d76a55b0c0.PNG) |

**Testing instructions:**
1. Copy the updated `vue-strap.min.js` to your MarkBind asset folder.
2. Run `markbind init` on an empty folder
3. Insert a `<panel header="...." dynamic>` with random contents in the panel body
4. Run `markbind serve` and inspect the panel before opening it,
 checking that `<div class="card-collapse ..." .. >` is not rendered.
5. Remove the `dynamic` attribute, repeat and check that it is rendered. 
6. Behaviour remains the same even if `src` is specified.