### PR TITLE
Dropdown: Show pointer cursor for dropdown button when integrated with other components

### DIFF
--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -152,4 +152,8 @@ export default {
   padding-left: 0.2rem;
   padding-right: 0.4rem;
 }
+
+.dropdown-toggle {
+  cursor: pointer;
+}
 </style>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

**What is the rationale for this request?**
When a dropdown is used inside a navigation bar, the dropdown title does not have a pointer cursor.

**What changes did you make? (Give an overview)**
Added a CSS so that the pointer cursor will appear.

**Provide some example code that this change will affect:**
NA

**Is there anything you'd like reviewers to focus on?**
NA

**Testing instructions:**
1. Build `vue-strap.min.js`.
2. Copy into the MarkBind repository on the [migrated website PR](https://github.com/MarkBind/markbind/pull/320).
3. `markbind serve docs`
4. The nav bar at the top should show the correct cursor when you hover over "User Guide".