### PR TITLE
Migrate closeable

### DIFF
--- a/src/directives/Closeable.js
+++ b/src/directives/Closeable.js
@@ -29,15 +29,15 @@ module.exports = {
 
     el.dataset.isShown = 'true';
     el.style.position = 'relative';
-    let message = el.getAttribute('alt') || 'Expand Content';
-    let $content = jQuery(`<div class="content"></div>`);
+    const message = el.getAttribute('alt') || 'Expand Content';
+    const $content = jQuery(`<div class="content"></div>`);
     jQuery(el).contents().appendTo($content);
     jQuery(el).empty();
     jQuery(el).append($content);
     jQuery(el).attr('class', `${el.className} closeable-wrapper`);
-    let $closeButton = jQuery('<span class="closeable-button label label-default hidden-print" style="display: none; position: absolute; top: -15px; left: -15px; cursor: pointer;background: #d9534f;"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>');
+    const $closeButton = jQuery('<span class="closeable-button label label-default hidden-print" style="display: none; position: absolute; top: -15px; left: -15px; cursor: pointer;background: #d9534f;"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>');
     jQuery(el).append($closeButton);
-    let $showLabel = jQuery(`<a class="closeable-show hidden-print" style="display: none; cursor: pointer;text-decoration: underline">${message}</a>`);
+    const $showLabel = jQuery(`<a class="closeable-show hidden-print" style="display: none; cursor: pointer;text-decoration: underline">${message}</a>`);
     jQuery(el).append($showLabel);
     $closeButton.click(onClose);
     $showLabel.click(onShow);

--- a/src/directives/Closeable.js
+++ b/src/directives/Closeable.js
@@ -1,44 +1,47 @@
 module.exports = {
-  isShown: true,
-  bind () {
-    jQuery(this.el).wrap(function () {
-      return `<div style="position: relative;"></div>`;
-    });
-    let message = this.el.getAttribute('alt') || 'Expand Content';
-    this.wrapper = jQuery(this.el).parent();
-    this.wrapper.attr('class', `${this.el.className} closeable-wrapper`);
-    let $closeButton = jQuery('<span class="closeable-button label label-default hidden-print" style="display: none; position: absolute; top: 0; left: 0; cursor: pointer;background: #d9534f;"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>');
-    this.wrapper.append($closeButton);
+  bind(el) {
+    function onClose() {
+      el.dataset.isShown = 'false';
+      $showLabel.show();
+      $closeButton.hide();
+      $content.get()[0].style.display = 'none';
+    }
+
+    function onShow() {
+      el.dataset.isShown = 'true';
+      $showLabel.hide();
+      $content.get()[0].style.display = '';
+    }
+
+    function onMouseOver() {
+      if (el.dataset.isShown === 'false') {
+        return;
+      }
+      $closeButton.show();
+    }
+
+    function onMouseOut() {
+      if (el.dataset.isShown === 'false') {
+        return;
+      }
+      $closeButton.hide();
+    }
+
+    el.dataset.isShown = 'true';
+    el.style.position = 'relative';
+    let message = el.getAttribute('alt') || 'Expand Content';
+    let $content = jQuery(`<div class="content"></div>`);
+    jQuery(el).contents().appendTo($content);
+    jQuery(el).empty();
+    jQuery(el).append($content);
+    jQuery(el).attr('class', `${el.className} closeable-wrapper`);
+    let $closeButton = jQuery('<span class="closeable-button label label-default hidden-print" style="display: none; position: absolute; top: -15px; left: -15px; cursor: pointer;background: #d9534f;"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>');
+    jQuery(el).append($closeButton);
     let $showLabel = jQuery(`<a class="closeable-show hidden-print" style="display: none; cursor: pointer;text-decoration: underline">${message}</a>`);
-    this.wrapper.append($showLabel);
-    this.closeButton = $closeButton;
-    this.showButton = $showLabel;
-    this.closeButton.click(this.onClose.bind(this));
-    this.showButton.click(this.onShow.bind(this));
-    this.wrapper.on('mouseover', this.onMouseOver.bind(this));
-    this.wrapper.on('mouseout', this.onMouseOut.bind(this));
-  },
-  onClose() {
-    this.isShown = false;
-    this.showButton.show();
-    this.closeButton.hide();
-    this.el.style.display = 'none';
-  },
-  onShow() {
-    this.isShown = true;
-    this.showButton.hide();
-    this.el.style.display = '';
-  },
-  onMouseOver() {
-    if (!this.isShown) {
-      return;
-    }
-    this.closeButton.show();
-  },
-  onMouseOut() {
-    if (!this.isShown) {
-      return;
-    }
-    this.closeButton.hide();
+    jQuery(el).append($showLabel);
+    $closeButton.click(onClose);
+    $showLabel.click(onShow);
+    jQuery(el).on('mouseover', onMouseOver);
+    jQuery(el).on('mouseout', onMouseOut);
   }
 };


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Other, please explain: Migration

Resolves https://github.com/MarkBind/markbind/issues/315

What changes did you make? (Give an overview)
custom directives doesn't have the `this` instance, so all callbacks are put inside `bind`.
Also, we cannot modify the el element and element outside it. Thus, instead of wrap the el with a div, we take out the contents inside, and then wrap it and append it to el.

Testing instructions:

1.Build vue-strap using `npm run build`.
2. Copy vue-strap.min.js from the dist folder in this repository, to the asset/js/ folder in markbind repository
3. Do markbind init on a new empty folder.
4. On its index.md, add this content:
```
<div v-closeable alt="architecture diagram examples" id="architecture-diagram-examples">
  <tip-box>
    <p><span class="glyphicon glyphicon-gift" aria-hidden="true"></span> Some example architecture diagrams:</p>
    <tabs>
      <tab header="TEAMMATES">
        <p><img src="https://github.com/TEAMMATES/teammates/raw/master/docs/images/highlevelArchitecture.png" width="700"><br></p>
        <p>
          <hr>
        </p>
      </tab>
      <tab header="se-edu/addressbook-level4">
        <p><img src="https://se-edu.github.io/addressbook-level4/images/Architecture.png" width="700"><br></p>
        <p>
          <hr>
        </p>
      </tab>
      <tab header="Example 1">
        <p><img src="https://upload.wikimedia.org/wikipedia/commons/5/5f/Accelerator_Architecture.png" width="700"><br>
          <sub><a href="https://commons.wikimedia.org/wiki/File:Accelerator_Architecture.png">source: https://commons.wikimedia.org</a></sub></p>
        <p>
          <hr>
        </p>
      </tab>
      <tab header="Example 2">
        <p><img src="https://upload.wikimedia.org/wikipedia/commons/b/b8/Firefox_OS_Architecture_diagram.png" width="700"><br>
          <sub><a href="https://upload.wikimedia.org/wikipedia/commons/b/b8/Firefox_OS_Architecture_diagram.png">source: https://commons.wikimedia.org</a></sub></p>
        <p>
          <hr>
        </p>
      </tab>
      <tab header="Example 3">
        <p><img src="https://upload.wikimedia.org/wikipedia/commons/0/06/SOA_Metamodel.svg" width="700"><br>
          <sub><a href="https://upload.wikimedia.org/wikipedia/commons/0/06/SOA_Metamodel.svg">source: https://commons.wikimedia.org</a></sub></p>
        <p>
          <hr>
        </p>
      </tab>
    </tabs>
  </tip-box>
</div>
```