### PR TITLE
Change Panel's behaviour to be dynamic by default

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -40,10 +40,10 @@
                     </slot>
                 </div>
             </div>
-            <template v-if="dynamicBool">
+            <template v-if="staticBool">
                 <div class="card-collapse"
                      ref="panel"
-                     v-if="localExpanded"
+                     v-show="localExpanded"
                 >
                     <div class="card-body">
                         <slot></slot>
@@ -58,7 +58,7 @@
             <template v-else>
                 <div class="card-collapse"
                      ref="panel"
-                     v-show="localExpanded"
+                     v-if="localExpanded"
                 >
                     <div class="card-body">
                         <slot></slot>
@@ -133,7 +133,7 @@
         type: Boolean,
         default: true
       },
-      dynamic: {
+      static: {
         type: Boolean,
         default: false
       }
@@ -161,8 +161,8 @@
       bottomSwitchBool () {
         return toBoolean(this.bottomSwitch);
       },
-      dynamicBool () {
-        return toBoolean(this.dynamic);
+      staticBool () {
+        return toBoolean(this.static);
       },
       // Vue 2.0 coerce migration end
       isExpandableCard () {
@@ -283,7 +283,7 @@
     },
     mounted() {
       this.$nextTick(function () {
-        if (this.hasSrc && (!this.dynamicBool || this.localExpanded)) {
+        if (this.hasSrc && (this.staticBool || this.localExpanded)) {
           this.$refs.retriever.fetch()
         }
       })


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of MarkBind/markbind#326

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
It has been discovered there are significant time and resource savings when defaulting to 'dynamic' behaviour within Panels.

**What changes did you make? (Give an overview)**
- Deprecate 'dynamic' prop 
- Add 'static' prop and invert existing Boolean logic that used the 'dynamic' prop 

**Testing instructions:**
1. Run `npm run build`, copy paste `vue-strap.min.js` to MarkBind's asset folder.
2. Test removal of 'dynamic' attribute and addition of 'static' attribute.