### PR TITLE
Rename 'static' prop to 'preload' prop

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -40,7 +40,7 @@
                     </slot>
                 </div>
             </div>
-            <template v-if="staticBool">
+            <template v-if="preloadBool">
                 <div class="card-collapse"
                      ref="panel"
                      v-show="localExpanded"
@@ -133,7 +133,7 @@
         type: Boolean,
         default: true
       },
-      static: {
+      preload: {
         type: Boolean,
         default: false
       }
@@ -161,8 +161,8 @@
       bottomSwitchBool () {
         return toBoolean(this.bottomSwitch);
       },
-      staticBool () {
-        return toBoolean(this.static);
+      preloadBool () {
+        return toBoolean(this.preload);
       },
       // Vue 2.0 coerce migration end
       isExpandableCard () {
@@ -283,7 +283,7 @@
     },
     mounted() {
       this.$nextTick(function () {
-        if (this.hasSrc && (this.staticBool || this.localExpanded)) {
+        if (this.hasSrc && (this.preloadBool || this.localExpanded)) {
           this.$refs.retriever.fetch()
         }
       })


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Other, refactor

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of MarkBind/markbind#326

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Refactor name to align with user request.

**What changes did you make? (Give an overview)**
- Rename 'static' into 'preload'.

**Testing instructions:**
1. Run `npm run build`, copy paste `vue-strap.min.js` to MarkBind's asset folder.
2. Test removal of 'static' attribute and addition of 'preload' attribute.