### PR TITLE
Fix closeable button position

### DIFF
--- a/src/directives/Closeable.js
+++ b/src/directives/Closeable.js
@@ -35,7 +35,7 @@ module.exports = {
     jQuery(el).empty();
     jQuery(el).append($content);
     jQuery(el).attr('class', `${el.className} closeable-wrapper`);
-    const $closeButton = jQuery('<span class="closeable-button label label-default hidden-print" style="display: none; position: absolute; top: 0px; left: 0px; cursor: pointer;background: #d9534f;"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>');
+    const $closeButton = jQuery('<span class="closeable-button label label-default hidden-print" style="display: none; position: absolute; top: 0; left: 0; cursor: pointer;background: #d9534f;"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>');
     jQuery(el).append($closeButton);
     const $showLabel = jQuery(`<a class="closeable-show hidden-print" style="display: none; cursor: pointer;text-decoration: underline">${message}</a>`);
     jQuery(el).append($showLabel);

--- a/src/directives/Closeable.js
+++ b/src/directives/Closeable.js
@@ -35,7 +35,7 @@ module.exports = {
     jQuery(el).empty();
     jQuery(el).append($content);
     jQuery(el).attr('class', `${el.className} closeable-wrapper`);
-    const $closeButton = jQuery('<span class="closeable-button label label-default hidden-print" style="display: none; position: absolute; top: -15px; left: -15px; cursor: pointer;background: #d9534f;"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>');
+    const $closeButton = jQuery('<span class="closeable-button label label-default hidden-print" style="display: none; position: absolute; top: 0px; left: 0px; cursor: pointer;background: #d9534f;"><span class="glyphicon glyphicon-remove" aria-hidden="true"></span></span>');
     jQuery(el).append($closeButton);
     const $showLabel = jQuery(`<a class="closeable-show hidden-print" style="display: none; cursor: pointer;text-decoration: underline">${message}</a>`);
     jQuery(el).append($showLabel);


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [X] Other, please explain: Migration

Part of MarkBind/markbind#333

What changes did you make? (Give an overview)
change button position

Testing instructions:

1.Build vue-strap using npm run build.
2. Copy vue-strap.min.js from the dist folder in this repository, to the asset/js/ folder in markbind repository
3. Do markbind init on a new empty folder.
4. On its index.md, add this content:
```
<div v-closeable alt="architecture diagram examples" id="architecture-diagram-examples">
  <tip-box>
    <p><span class="glyphicon glyphicon-gift" aria-hidden="true"></span> Some example architecture diagrams:</p>
    <tabs>
      <tab header="TEAMMATES">
        <p><img src="https://github.com/TEAMMATES/teammates/raw/master/docs/images/highlevelArchitecture.png" width="700"><br></p>
        <p>
          <hr>
        </p>
      </tab>
      <tab header="se-edu/addressbook-level4">
        <p><img src="https://se-edu.github.io/addressbook-level4/images/Architecture.png" width="700"><br></p>
        <p>
          <hr>
        </p>
      </tab>
      <tab header="Example 1">
        <p><img src="https://upload.wikimedia.org/wikipedia/commons/5/5f/Accelerator_Architecture.png" width="700"><br>
          <sub><a href="https://commons.wikimedia.org/wiki/File:Accelerator_Architecture.png">source: https://commons.wikimedia.org</a></sub></p>
        <p>
          <hr>
        </p>
      </tab>
      <tab header="Example 2">
        <p><img src="https://upload.wikimedia.org/wikipedia/commons/b/b8/Firefox_OS_Architecture_diagram.png" width="700"><br>
          <sub><a href="https://upload.wikimedia.org/wikipedia/commons/b/b8/Firefox_OS_Architecture_diagram.png">source: https://commons.wikimedia.org</a></sub></p>
        <p>
          <hr>
        </p>
      </tab>
      <tab header="Example 3">
        <p><img src="https://upload.wikimedia.org/wikipedia/commons/0/06/SOA_Metamodel.svg" width="700"><br>
          <sub><a href="https://upload.wikimedia.org/wikipedia/commons/0/06/SOA_Metamodel.svg">source: https://commons.wikimedia.org</a></sub></p>
        <p>
          <hr>
        </p>
      </tab>
    </tabs>
  </tip-box>
</div>
```