### PR TITLE
Enable seamless Panel's caret to stay inline

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -17,7 +17,7 @@
                  @click.prevent.stop="isExpandableCard && toggle()"
                  @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
                 <div class="header-wrapper">
-                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-show="showCaret"></span>
+                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-if="showCaret && hasCustomHeader" aria-hidden="true"></span>
                     <slot name="header">
                         <div :class="['card-title', cardType, {'text-white':!isLightBg}]" v-html="headerContent"></div>
                     </slot>
@@ -28,12 +28,12 @@
                                       @click.native.stop.prevent="expand()"
                                       @is-open-event="retrieveOnOpen" :is-light-bg="isLightBg"></panel-switch>
                         <button type="button" :class="['close-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
-                                v-show="!isSeamless ? (!noCloseBool) : onHeaderHover"
+                                v-show="isSeamless ? onHeaderHover : (!noCloseBool)"
                                 @click.stop="close()">
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                         </button>
                         <button type="button" :class="['popup-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
-                                v-show="this.popupUrl !== null"
+                                v-show="((this.popupUrl !== null) && (!isSeamless || onHeaderHover))"
                                 @click.stop="openPopup()">
                             <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span>
                         </button>
@@ -201,10 +201,16 @@
         return this.cardType === 'bg-light' || this.cardType === 'bg-white' || this.cardType === 'bg-warning';
       },
       headerContent () {
-        return md.render(this.header);
+        if (this.isSeamless) {
+            return this.caretHtml + ' ' + this.renderedHeader;
+        }
+        return this.renderedHeader;
       },
       altContent () {
-        return this.alt && md.render(this.alt) || md.render(this.header);
+        return this.alt && md.render(this.alt) || this.renderedHeader;
+      },
+      renderedHeader () {
+        return md.renderInline(this.header);
       },
       hasSrc () {
         return this.src && this.src.length > 0;
@@ -215,6 +221,16 @@
         } else {
           return onHeaderHover;
         }
+      },
+      caretHtml () {
+        if (this.localExpanded) {
+          return '<span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>'
+        } else {
+          return '<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>'
+        }
+      },
+      hasCustomHeader () {
+        return this.$slots.header !== undefined;
       }
     },
     data () {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes MarkBind/markbind#337

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Seamless Panels have its caret pushed to the previous line when the Panel width is too small. The expected behaviour is having the header text wrap around while having the caret inline. 

**What changes did you make? (Give an overview)**
- Added a new toggle-able inline caret to default header slot rendered via `v-html="headerContent"`.
- Cleaned up some logic for existing caret.
- Change popup button to only appear on mouse over for seamless Panels. 

Before | After
--- | ---
![337-before](https://user-images.githubusercontent.com/31084833/42799931-3e99b10e-89cc-11e8-99cc-34725866c3e1.PNG) | ![337-after](https://user-images.githubusercontent.com/31084833/42799938-428a133a-89cc-11e8-8dc9-876d82e771bb.PNG)

Note |
--- |
When using `slot="header"` , the problem will re-emerge as there is no way to insert the caret inside the slotted element without using `Cheerio / JQuery`. 

**Is there anything you'd like reviewers to focus on?**
- Logic in methods and template

**Testing instructions:**
- Run `npm run build` and paste the updated `vue-strap.min.js` into MarkBind's asset folder.
- Run `markbind init`, author a seamless panel with a long header.
- Run `markbind serve` and reduce window width.
- Check that the caret stays inline and is toggle-able.