### PR TITLE
Align Panel buttons on mobile and added responsive CSS

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -372,13 +372,15 @@
         font-size: 10px !important;
         float: right;
         padding: 3px 8px !important;
+        margin-left: 3px;
+        margin-top: 2px;
     }
 
     .popup-button {
         font-size: 10px !important;
         float: right;
+        margin-top: 2px;
         padding: 3px 8px !important;
-        margin-right: 4px;
     }
 
     .morph {

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -386,4 +386,28 @@
     .morph {
         display: inline-block;
     }
+
+    /* Bootstrap extra small(xs) responsive breakpoint */
+    @media (max-width: 575.98px) {
+
+        .header-wrapper {
+            width: 88%;
+        }
+
+        .button-wrapper {
+            width: 12%;
+        }
+
+        .card-body {
+            padding: 0.5rem;
+        }
+
+        .card-collapse > hr {
+            margin-top: 1.5rem;
+        }
+
+        .card-header {
+            padding: 0.5rem;
+        }
+    }
 </style>

--- a/src/PanelSwitch.vue
+++ b/src/PanelSwitch.vue
@@ -44,5 +44,6 @@
         float: right;
         padding: 3px 8px !important;
         margin-left: 3px;
+        margin-top: 2px;
     }
 </style>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of MarkBind/markbind#335

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
On mobile sites, Panel buttons are mis-aligned and the padding is too generous. 

**What changes did you make? (Give an overview)**
- Change buttons' CSS to align them
- Trimmed padding and gave Panel headers more width when rendered on mobile. 

Before | After
--- | ---
![335-panel-before](https://user-images.githubusercontent.com/31084833/42801404-121aa51a-89d2-11e8-9753-beff4ca4a093.PNG) | ![335-panel-after](https://user-images.githubusercontent.com/31084833/42801417-1a0013a0-89d2-11e8-877b-317de7f467fd.PNG)


**Is there anything you'd like reviewers to focus on?**
- New responsive CSS

**Testing instructions:**
- Run `npm run build` and paste the updated `vue-strap.min.js` into MarkBind's asset folder.
- Run `markbind init`, author a panel with `popup-url`.
- Run `markbind serve` and reduce window size.
- Inspect the new Panel's style. 