### PR TITLE
Allow minimised Panel text to wrap around

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -387,6 +387,10 @@
         display: inline-block;
     }
 
+    .morph-display-wrapper {
+        white-space: normal;
+    }
+
     /* Bootstrap extra small(xs) responsive breakpoint */
     @media (max-width: 575.98px) {
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of MarkBind/markbind#335

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Minimised panel text could overflow outside its parent container. 

**What changes did you make? (Give an overview)**
- Add CSS so the text can wrap around without overflowing. 

Before | After
--- | ---
![335-panel-min-before](https://user-images.githubusercontent.com/31084833/42872215-ea5c34e8-8aae-11e8-9b97-75caa616090f.PNG) | ![335-panel-min-after](https://user-images.githubusercontent.com/31084833/42872223-ee6eeeea-8aae-11e8-977f-5934c1330f88.PNG)


**Testing instructions:**
- Use `Netlify Preview`