### PR TITLE
Add id for panel container

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -1,5 +1,5 @@
 <template>
-    <span class="card-container">
+    <span class="card-container" ref="cardContainer">
         <div class="morph" v-show="localMinimized">
             <button :class="['morph-display-wrapper', 'btn', btnType, 'card-title']" @click="open()">
                 <template v-if="altContent">
@@ -333,7 +333,12 @@
           this.$refs.headerWrapper.innerHTML =
             this.insertCaretInsideHeader(this.$refs.headerWrapper.innerHTML);
         }
-      })
+      });
+      const panelHeader = this.$slots.header ? this.$refs.headerWrapper.innerHTML : this.headerContent;
+      const panelHeaderText = jQuery(panelHeader).wrap('<div></div>').parent().find(':header').text();
+      if (panelHeaderText) {
+        this.$refs.cardContainer.setAttribute('id', panelHeaderText.trim().replace(/\s+/g, '-').toLowerCase());
+      }
     },
   }
 </script>


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Relates MarkBind/markbind#336

What is the rationale for this request?
panel header rendered doesn't have an id when not using slot. And even if slot is used, still cannot jump to that element.

What changes did you make? (Give an overview)
Add id for panel's top level container

Testing instructions:

1.run npm run build in vue-strap repo
2.copy vue-strap.min.js to markbind repo
3.test on 2103 website.