### PR TITLE
Panel: Change header markdown rendering to non-inline

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -210,7 +210,7 @@
         return this.alt && md.render(this.alt) || this.renderedHeader;
       },
       renderedHeader () {
-        return md.renderInline(this.header);
+        return md.render(this.header);
       },
       hasSrc () {
         return this.src && this.src.length > 0;

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -201,16 +201,43 @@
         return this.cardType === 'bg-light' || this.cardType === 'bg-white' || this.cardType === 'bg-warning';
       },
       headerContent () {
-        if (this.isSeamless) {
-            return this.caretHtml + ' ' + this.renderedHeader;
-        }
         return this.renderedHeader;
       },
       altContent () {
         return this.alt && md.render(this.alt) || this.renderedHeader;
       },
       renderedHeader () {
-        return md.render(this.header);
+        let htmlRenderedHeader = md.render(this.header).trim();
+
+        if (this.isSeamless) {
+          // insert the caret to the header content
+          let caretAdded = false;
+
+          // if the header content is wrapped by a <p> or any <h1>, <h2>, ...
+          // then it must be inserted inside these HTML tags, otherwise the
+          // header content will not be in the same line as caret
+          const tags = [
+            ['<p>', '</p>'],
+            ['<h1>', '</h1>'],
+            ['<h2>', '</h2>'],
+            ['<h3>', '</h3>'],
+            ['<h4>', '</h4>'],
+            ['<h5>', '</h5>'],
+            ['<h6>', '</h6>']];
+
+          tags.forEach(header => {
+            if (!caretAdded && htmlRenderedHeader.startsWith(header[0]))  {
+              htmlRenderedHeader = jQuery(htmlRenderedHeader).unwrap().prepend(this.caretHtml + ' ')
+                .wrap(header[0] + header[1]).parent().html();
+              caretAdded = true;
+            }
+          });
+
+          if (!caretAdded) {
+            htmlRenderedHeader = this.caretHtml + ' ' + htmlRenderedHeader;
+          }
+        }
+        return htmlRenderedHeader;
       },
       hasSrc () {
         return this.src && this.src.length > 0;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

**What is the rationale for this request?**
Sometimes, panel uses Markdown headings. However, due to changes in #74, the Markdown rendering technique used is inline, and inline text normally do not use headings, so they are not parsed, and as a result they are broken.

**What changes did you make? (Give an overview)**
* Switch the rendering from inline to non-inline.
* Fix the seamless panel bug, which was the reason why it was changed to inline in the first place.

**Provide some example code that this change will affect:**

```html
<panel header="# Some headings">
</panel>
```

Before | After 
--- | ---
<img src="https://user-images.githubusercontent.com/3168908/42979633-c392a7d6-8c05-11e8-8229-07fe6be88061.png" />|<img src="https://user-images.githubusercontent.com/3168908/42979631-c35ed0d2-8c05-11e8-93cb-29916a791c50.png" />


**Is there anything you'd like reviewers to focus on?**
NA

**Testing instructions:**
1. Build bootstrap, copy `vue-strap.min.js` to MarkBind repository.
2. Run `markbind serve docs` and ensure that no panels are broken in Component Reference.
3. Also try the following `index.md`:

```html
<panel type="seamless" header="Normal">
</panel>

<panel type="seamless" header="# Heading 1">
</panel>

<panel type="seamless" header="## Heading 2">
</panel>

<panel type="seamless" header="### Heading 3">
</panel>

<panel type="seamless" header="#### Heading 4">
</panel>

<panel type="seamless" header="##### Heading 5">
</panel>

<panel type="seamless" header="###### Heading 6">
</panel>

<panel header="Normal panel">
</panel>

<panel header="# Normal panel 2">
</panel>
```