### PR TITLE
Fix wrong tooltip location if tooltipped text has line breaks

### DIFF
--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -74,17 +74,10 @@ export default {
       setTimeout(() => {
         const popover = this.$refs.popover
 
-        let finalPosition = {
-          top: this.position.top,
-          left: this.position.left,
-          width: popover.offsetWidth,
-          height: popover.offsetHeight
-        }
-
         this.isPopover = Array.some(popover.classList, classname => classname === 'popover');
         trigger.offsetParent.style.position = 'relative';
         popover.style.position = 'absolute';
-        finalPosition = this.calculateOffset(trigger, popover, finalPosition)
+        let finalPosition = this.calculateOffset(trigger, popover)
         if (this.$refs.arrow) {
           let delta = this.getViewportAdjustedDelta(finalPosition);
           if (delta.left) finalPosition.left += delta.left
@@ -98,13 +91,10 @@ export default {
         popover.style.left = finalPosition.left + 'px';
       }, 20)
     },
-    calculateOffset (trigger, popover, initialPosition) {
+    calculateOffset (trigger, popover) {
       const finalPosition = {
-        top: initialPosition.top,
-        left: initialPosition.left,
-        width: initialPosition.width,
-        height: initialPosition.height
-      }
+        top: 0, left: 0, width: popover.offsetWidth, height: popover.offsetHeight
+      };
 
       switch (this.placement) {
         case 'top' :

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -75,8 +75,6 @@ export default {
         const popover = this.$refs.popover
 
         this.isPopover = Array.some(popover.classList, classname => classname === 'popover');
-        trigger.offsetParent.style.position = 'relative';
-        popover.style.position = 'absolute';
         let finalPosition = this.calculateOffset(trigger, popover)
         if (this.$refs.arrow) {
           let delta = this.getViewportAdjustedDelta(finalPosition);
@@ -91,36 +89,47 @@ export default {
         popover.style.left = finalPosition.left + 'px';
       }, 20)
     },
+    getBoundingBoxRelativeToDocument(element) {
+      const boundingClientRect = element.getBoundingClientRect();
+      const boundingBox = {
+        left: boundingClientRect.left + (window.pageXOffset || document.documentElement.scrollLeft),
+        top: boundingClientRect.top + (window.pageYOffset || document.documentElement.scrollTop),
+        width: boundingClientRect.width,
+        height: boundingClientRect.height
+      };
+      return boundingBox;
+    },
     calculateOffset (trigger, popover) {
       const finalPosition = {
         top: 0, left: 0, width: popover.offsetWidth, height: popover.offsetHeight
       };
+      const triggerBoundingBox = this.getBoundingBoxRelativeToDocument(trigger);
 
       switch (this.placement) {
         case 'top' :
-          finalPosition.left = trigger.offsetLeft - popover.offsetWidth / 2 + trigger.offsetWidth / 2
-          finalPosition.top = trigger.offsetTop - popover.offsetHeight
+          finalPosition.left = triggerBoundingBox.left + (triggerBoundingBox.width - popover.offsetWidth) / 2;
+          finalPosition.top = triggerBoundingBox.top - popover.offsetHeight;
           if (this.isPopover) {
             finalPosition.top -= this.$refs.arrow.offsetHeight;
           }
-          break
+          break;
         case 'left':
-          finalPosition.left = trigger.offsetLeft - popover.offsetWidth
-          finalPosition.top = trigger.offsetTop + trigger.offsetHeight / 2 - popover.offsetHeight / 2
+          finalPosition.left = triggerBoundingBox.left - popover.offsetWidth;
+          finalPosition.top = triggerBoundingBox.top + (triggerBoundingBox.height - popover.offsetHeight) / 2;
           if (this.isPopover) {
             finalPosition.left -= this.$refs.arrow.offsetWidth;
           }
-          break
+          break;
         case 'right':
-          finalPosition.left = trigger.offsetLeft + trigger.offsetWidth
-          finalPosition.top = trigger.offsetTop + trigger.offsetHeight / 2 - popover.offsetHeight / 2
-          break
+          finalPosition.left = triggerBoundingBox.left + triggerBoundingBox.width;
+          finalPosition.top = triggerBoundingBox.top + (triggerBoundingBox.height - popover.offsetHeight) / 2;
+          break;
         case 'bottom':
-          finalPosition.left = trigger.offsetLeft - popover.offsetWidth / 2 + trigger.offsetWidth / 2
-          finalPosition.top = trigger.offsetTop + trigger.offsetHeight
-          break
+          finalPosition.left = triggerBoundingBox.left + (triggerBoundingBox.width - popover.offsetWidth) / 2;
+          finalPosition.top = triggerBoundingBox.top + triggerBoundingBox.height;
+          break;
         default:
-          console.warn('Wrong placement prop')
+          console.warn('Wrong placement prop');
       }
 
       return finalPosition;

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -85,20 +85,17 @@ export default {
         trigger.offsetParent.style.position = 'relative';
         popover.style.position = 'absolute';
         finalPosition = this.calculateOffset(trigger, popover, finalPosition)
-        popover.style.top = finalPosition.top + 'px'
-        popover.style.left = finalPosition.left + 'px'
         if (this.$refs.arrow) {
-          finalPosition = this.calculateOffset(trigger, popover, finalPosition) // Update for CSS adjustment
           let delta = this.getViewportAdjustedDelta(finalPosition);
           if (delta.left) finalPosition.left += delta.left
           else finalPosition.top += delta.top
-          popover.style.top = finalPosition.top + 'px'
-          popover.style.left = finalPosition.left + 'px'
           let isVertical = /top|bottom/.test(this.placement)
           let arrowDelta = isVertical ? delta.left * 2 : delta.top * 2;
           let arrowOffsetPosition = isVertical ? popover.offsetWidth : popover.offsetHeight
           this.adjustArrow(arrowDelta, arrowOffsetPosition, isVertical)
         }
+        popover.style.top = finalPosition.top + 'px';
+        popover.style.left = finalPosition.left + 'px';
       }, 20)
     },
     calculateOffset (trigger, popover, initialPosition) {

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -89,11 +89,9 @@ export default {
         popover.style.top = finalPosition.top + 'px'
         popover.style.left = finalPosition.left + 'px'
         if (this.$refs.arrow) {
-          let actualWidth  = popover.offsetWidth
-          let actualHeight = popover.offsetHeight
           finalPosition = this.calculateOffset(trigger, popover, finalPosition) // Update for CSS adjustment
           finalPosition = this.updateOffsetForMargins(popover, finalPosition)
-          let delta = this.getViewportAdjustedDelta(finalPosition, actualWidth, actualHeight)
+          let delta = this.getViewportAdjustedDelta(finalPosition);
           if (delta.left) finalPosition.left += delta.left
           else finalPosition.top += delta.top
           popover.style.top = finalPosition.top + 'px'
@@ -162,7 +160,7 @@ export default {
 
       return finalPosition;
     },
-    getViewportAdjustedDelta (pos, actualWidth, actualHeight) {
+    getViewportAdjustedDelta (pos) {
       var delta = { top: 0, left: 0 };
       let vpRect = this._viewport.getBoundingClientRect();
       let vpOffset = { top: 0, left: 0 };
@@ -172,7 +170,7 @@ export default {
 
       if (/right|left/.test(this.placement)) {
         var topEdgeOffset    = pos.top - scroll
-        var bottomEdgeOffset = pos.top - scroll + actualHeight
+        var bottomEdgeOffset = pos.top - scroll + pos.height;
         if (topEdgeOffset < viewportDimensions.top) { // top overflow
           delta.top = viewportDimensions.top - topEdgeOffset
         } else if (bottomEdgeOffset > viewportDimensions.top + viewportDimensions.height) { // bottom overflow
@@ -180,7 +178,7 @@ export default {
         }
       } else {
         var leftEdgeOffset  = pos.left
-        var rightEdgeOffset = pos.left + actualWidth
+        var rightEdgeOffset = pos.left + pos.width;
         if (leftEdgeOffset < viewportDimensions.left) { // left overflow
           delta.left = viewportDimensions.left - leftEdgeOffset
         } else if (rightEdgeOffset > viewportDimensions.right) { // right overflow

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -85,12 +85,10 @@ export default {
         trigger.offsetParent.style.position = 'relative';
         popover.style.position = 'absolute';
         finalPosition = this.calculateOffset(trigger, popover, finalPosition)
-        finalPosition = this.updateOffsetForMargins(popover, finalPosition)
         popover.style.top = finalPosition.top + 'px'
         popover.style.left = finalPosition.left + 'px'
         if (this.$refs.arrow) {
           finalPosition = this.calculateOffset(trigger, popover, finalPosition) // Update for CSS adjustment
-          finalPosition = this.updateOffsetForMargins(popover, finalPosition)
           let delta = this.getViewportAdjustedDelta(finalPosition);
           if (delta.left) finalPosition.left += delta.left
           else finalPosition.top += delta.top
@@ -136,26 +134,6 @@ export default {
           break
         default:
           console.warn('Wrong placement prop')
-      }
-
-      return finalPosition;
-    },
-    updateOffsetForMargins (popover, initialPosition) {
-      const finalPosition = {
-        top: initialPosition.top,
-        left: initialPosition.left,
-        width: initialPosition.width,
-        height: initialPosition.height
-      }
-
-      const rect = popover.getBoundingClientRect()
-      if (rect.left < 0) {
-        finalPosition.left -= rect.left
-        const marginLeft = parseInt(jQuery(popover).css('margin-left'), 10)
-        if (marginLeft < 0) {
-          finalPosition.left += marginLeft
-          popover.style.marginLeft = 0
-        }
       }
 
       return finalPosition;

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -73,23 +73,31 @@ export default {
       }
       setTimeout(() => {
         const popover = this.$refs.popover
+
+        let finalPosition = {
+          top: this.position.top,
+          left: this.position.left,
+          width: popover.offsetWidth,
+          height: popover.offsetHeight
+        }
+
         this.isPopover = Array.some(popover.classList, classname => classname === 'popover');
         trigger.offsetParent.style.position = 'relative';
         popover.style.position = 'absolute';
-        this.calculateOffset(trigger, popover)
-        this.updateOffsetForMargins(popover)
-        popover.style.top = this.position.top + 'px'
-        popover.style.left = this.position.left + 'px'
+        finalPosition = this.calculateOffset(trigger, popover, finalPosition)
+        finalPosition = this.updateOffsetForMargins(popover, finalPosition)
+        popover.style.top = finalPosition.top + 'px'
+        popover.style.left = finalPosition.left + 'px'
         if (this.$refs.arrow) {
           let actualWidth  = popover.offsetWidth
           let actualHeight = popover.offsetHeight
-          this.calculateOffset(trigger, popover) // Update for CSS adjustment
-          this.updateOffsetForMargins(popover)
-          let delta = this.getViewportAdjustedDelta(this.position, actualWidth, actualHeight)
-          if (delta.left) this.position.left += delta.left
-          else this.position.top += delta.top
-          popover.style.top = this.position.top + 'px'
-          popover.style.left = this.position.left + 'px'
+          finalPosition = this.calculateOffset(trigger, popover, finalPosition) // Update for CSS adjustment
+          finalPosition = this.updateOffsetForMargins(popover, finalPosition)
+          let delta = this.getViewportAdjustedDelta(finalPosition, actualWidth, actualHeight)
+          if (delta.left) finalPosition.left += delta.left
+          else finalPosition.top += delta.top
+          popover.style.top = finalPosition.top + 'px'
+          popover.style.left = finalPosition.left + 'px'
           let isVertical = /top|bottom/.test(this.placement)
           let arrowDelta = isVertical ? delta.left * 2 : delta.top * 2;
           let arrowOffsetPosition = isVertical ? popover.offsetWidth : popover.offsetHeight
@@ -97,44 +105,62 @@ export default {
         }
       }, 20)
     },
-    calculateOffset (trigger, popover) {
+    calculateOffset (trigger, popover, initialPosition) {
+      const finalPosition = {
+        top: initialPosition.top,
+        left: initialPosition.left,
+        width: initialPosition.width,
+        height: initialPosition.height
+      }
+
       switch (this.placement) {
         case 'top' :
-          this.position.left = trigger.offsetLeft - popover.offsetWidth / 2 + trigger.offsetWidth / 2
-          this.position.top = trigger.offsetTop - popover.offsetHeight
+          finalPosition.left = trigger.offsetLeft - popover.offsetWidth / 2 + trigger.offsetWidth / 2
+          finalPosition.top = trigger.offsetTop - popover.offsetHeight
           if (this.isPopover) {
-            this.position.top -= this.$refs.arrow.offsetHeight;
+            finalPosition.top -= this.$refs.arrow.offsetHeight;
           }
           break
         case 'left':
-          this.position.left = trigger.offsetLeft - popover.offsetWidth
-          this.position.top = trigger.offsetTop + trigger.offsetHeight / 2 - popover.offsetHeight / 2
+          finalPosition.left = trigger.offsetLeft - popover.offsetWidth
+          finalPosition.top = trigger.offsetTop + trigger.offsetHeight / 2 - popover.offsetHeight / 2
           if (this.isPopover) {
-            this.position.left -= this.$refs.arrow.offsetWidth;
+            finalPosition.left -= this.$refs.arrow.offsetWidth;
           }
           break
         case 'right':
-          this.position.left = trigger.offsetLeft + trigger.offsetWidth
-          this.position.top = trigger.offsetTop + trigger.offsetHeight / 2 - popover.offsetHeight / 2
+          finalPosition.left = trigger.offsetLeft + trigger.offsetWidth
+          finalPosition.top = trigger.offsetTop + trigger.offsetHeight / 2 - popover.offsetHeight / 2
           break
         case 'bottom':
-          this.position.left = trigger.offsetLeft - popover.offsetWidth / 2 + trigger.offsetWidth / 2
-          this.position.top = trigger.offsetTop + trigger.offsetHeight
+          finalPosition.left = trigger.offsetLeft - popover.offsetWidth / 2 + trigger.offsetWidth / 2
+          finalPosition.top = trigger.offsetTop + trigger.offsetHeight
           break
         default:
           console.warn('Wrong placement prop')
       }
+
+      return finalPosition;
     },
-    updateOffsetForMargins (popover) {
+    updateOffsetForMargins (popover, initialPosition) {
+      const finalPosition = {
+        top: initialPosition.top,
+        left: initialPosition.left,
+        width: initialPosition.width,
+        height: initialPosition.height
+      }
+
       const rect = popover.getBoundingClientRect()
       if (rect.left < 0) {
-        this.position.left -= rect.left
+        finalPosition.left -= rect.left
         const marginLeft = parseInt(jQuery(popover).css('margin-left'), 10)
         if (marginLeft < 0) {
-          this.position.left += marginLeft
+          finalPosition.left += marginLeft
           popover.style.marginLeft = 0
         }
       }
+
+      return finalPosition;
     },
     getViewportAdjustedDelta (pos, actualWidth, actualHeight) {
       var delta = { top: 0, left: 0 };


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

Fixes MarkBind/markbind#338.

**What is the rationale for this request?**
Tooltip location is wrong when the tooltipped text wraps to multiple lines.

**What changes did you make? (Give an overview)**
Changed the logic such that the position is always determined by the top-left of the tooltippped-text, and remove the involvement of the width and height as much as possible.

**Provide some example code that this change will affect:**
NA

**Is there anything you'd like reviewers to focus on?**
1. Whether the tooltip looks better with the new implementation.

**Testing instructions:**
1. Run `npm run build`, copy `vue-strap.min.js` over to MarkBind.
2. Run `markbind serve docs` and ensure that nothing goes wrong.
3. Alternatively, try with this content `index.md`:

```html
<tooltip content="hi"><i>coupling</i></tooltip>
<tooltip placement="bottom" content="hi"><i>coupling</i></tooltip>
<tooltip placement="left" content="hi"><i>coupling</i></tooltip>
<tooltip placement="right" content="hi"><i>coupling</i></tooltip>

cupidatat non proident, sunt in culpa qui <tooltip content="hi"><i> quis nostrud exercitation ullamco laboris nisi cillum dolore eu fugiat nulla pariatur. Excepteur sint</i></tooltip> cillum dolore eu fugiat nulla pariatur. dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

cupidatat non proident, sunt in culpa qui <tooltip placement="bottom" content="hi"><i> quis nostrud exercitation ullamco laboris nisi cillum dolore eu fugiat nulla pariatur. Excepteur sint</i></tooltip> cillum dolore eu fugiat nulla pariatur. dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

cupidatat non proident, sunt in culpa qui <tooltip placement="left" content="hi"><i> quis nostrud exercitation ullamco laboris nisi cillum dolore eu fugiat nulla pariatur. Excepteur sint</i></tooltip> cillum dolore eu fugiat nulla pariatur. dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

cupidatat non proident, sunt in culpa qui <tooltip placement="right" content="hi"><i> quis nostrud exercitation ullamco laboris nisi cillum dolore eu fugiat nulla pariatur. Excepteur sint</i></tooltip> cillum dolore eu fugiat nulla pariatur. dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

<tooltip placement="left" content="bye">This tooltip is on the left.</tooltip>

<div align="right">
  <tooltip placement="right" content="bye">This tooltip is on the right.</tooltip>
</div>

More about <trigger for="tt:trigger_id">trigger</trigger>.
<tooltip id="tt:trigger_id" content="This tooltip triggered by a trigger"></tooltip>
<br>
This is the same <trigger for="tt:trigger_id">trigger</trigger> as last one.

Week         | Activities
-------------|-----------
6 (mid-v1.1) |  <tooltip content="User Guide">User Guide</tooltip>

Week         | Activities
-------------|-----------
6 (mid-v1.1) |  <popover content="User Guide">User Guide</popover>
```