### PR TITLE
Enable seamless Panel's caret to stay inline for custom header slots

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -216,19 +216,10 @@
           // if the header content is wrapped by a <p> or any <h1>, <h2>, ...
           // then it must be inserted inside these HTML tags, otherwise the
           // header content will not be in the same line as caret
-          const tags = [
-            ['<p>', '</p>'],
-            ['<h1>', '</h1>'],
-            ['<h2>', '</h2>'],
-            ['<h3>', '</h3>'],
-            ['<h4>', '</h4>'],
-            ['<h5>', '</h5>'],
-            ['<h6>', '</h6>']];
-
-          tags.forEach(header => {
-            if (!caretAdded && htmlRenderedHeader.startsWith(header[0]))  {
-              htmlRenderedHeader = jQuery(htmlRenderedHeader).unwrap().prepend(this.caretHtml + ' ')
-                .wrap(header[0] + header[1]).parent().html();
+          const tags = ['<p>', '<h1>', '<h2>', '<h3>', '<h4>', '<h5>', '<h6>'];
+          tags.forEach(tag => {
+            if (!caretAdded && htmlRenderedHeader.startsWith(tag))  {
+              htmlRenderedHeader = this.insertCaretInsideHeader(htmlRenderedHeader);
               caretAdded = true;
             }
           });
@@ -301,6 +292,11 @@
         if (isOpen && this.hasSrc) {
           this.$refs.retriever.fetch()
         }
+      },
+      insertCaretInsideHeader(originalHeaderHTML) {
+        const wrappedElementName = jQuery(originalHeaderHTML).attr("name");
+        return jQuery(originalHeaderHTML).unwrap().prepend(this.caretHtml + ' ')
+            .wrap(`<${wrappedElementName}></${wrappedElementName}>`).parent().html();
       }
     },
     watch: {

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -206,6 +206,10 @@
         return this.alt && md.render(this.alt) || this.renderedHeader;
       },
       renderedHeader () {
+        if (!this.header) {
+          return '';
+        }
+
         let htmlRenderedHeader = md.render(this.header).trim();
 
         if (this.isSeamless) {

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -16,8 +16,7 @@
             <div :class="['card-header',{'header-toggle':isExpandableCard}, cardType, borderType]"
                  @click.prevent.stop="isExpandableCard && toggle()"
                  @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
-                <div class="header-wrapper">
-                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-if="showCaret && hasCustomHeader" aria-hidden="true"></span>
+                <div class="header-wrapper" ref="headerWrapper">
                     <slot name="header">
                         <div :class="['card-title', cardType, {'text-white':!isLightBg}]" v-html="headerContent"></div>
                     </slot>
@@ -324,6 +323,11 @@
       this.$nextTick(function () {
         if (this.hasSrc && (this.preloadBool || this.expandedBool)) {
           this.$refs.retriever.fetch()
+        }
+
+        if (this.hasCustomHeader) {
+          this.$refs.headerWrapper.innerHTML =
+            this.insertCaretInsideHeader(this.$refs.headerWrapper.innerHTML);
         }
       })
     },


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

**What is the rationale for this request?**
Previously, on #74, we enable seamless Panel's caret to stay inline.

However, that logic only works if it is not using custom header slots, so the caret will break for custom cases, like in [here](https://github.com/MarkBind/vue-strap/pull/74#issuecomment-406941896). This can be very irritating for the author.


**What changes did you make? (Give an overview)**
This PR will fix the problem mentioned above, by implementing the logic for custom header slots.

**Provide some example code that this change will affect:**
NIL

**Is there anything you'd like reviewers to focus on?**
NIL

**Testing instructions:**
1. Run `npm run build`, and copy `vue-strap.min.js` to MarkBind repository.
2. Create a new MarkBind website with the following code in `index.md`:
```html
<panel type="seamless">
<span slot="header" class="card-title">
This header won't break even if I used <code>card-title</code>, hooray!
</span>
</panel>

<panel type="seamless">
<span slot="header">
No breaking as <code>card-title</code> not used, hip hip hooray!
</span>
</panel>

<panel type="seamless" header="Normal seamless">
Normal seamless panel content.
</panel>
```
3. Run `markbind serve`. Ensure that all the panel headings are inline even when the window is resized to be very small.
