### PR TITLE
Adjust panel heading width

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -365,13 +365,12 @@
 
     .header-wrapper {
         display: inline-block;
-        width: 72%;
+        width: calc(100% - 32px);
     }
 
     .button-wrapper {
         float: right;
         display: inline-block;
-        width: 28%;
     }
 
     .header-toggle {


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Fixes https://github.com/MarkBind/markbind/issues/370

What is the rationale for this request?
Current: headings overflow to next line although there seems to be enough space to keep them in one line. Should not use percentage to specify the width, as button has fixed width.

What changes did you make? (Give an overview)
change width of header wrapper to `100% - button width`

Testing instructions:
1. `npm run build` copy paste vue-strap.min.js
2. check 2103 website week3.1b heading not overflow