### PR TITLE
Fix seamless panel caret

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -16,8 +16,10 @@
             <div :class="['card-header',{'header-toggle':isExpandableCard}, cardType, borderType]"
                  @click.prevent.stop="isExpandableCard && toggle()"
                  @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
-                <div class="header-wrapper">
+                <div class="caret-wrapper">
                     <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-show="showCaret"></span>
+                </div>
+                <div class="header-wrapper">
                     <slot name="header">
                         <div :class="['card-title', cardType, {'text-white':!isLightBg}]" v-html="headerContent"></div>
                     </slot>
@@ -316,15 +318,21 @@
         margin: 0px !important;
     }
 
+    .caret-wrapper {
+        float: left;
+        display: inline-block;
+        width: 32px;
+    }
+
     .header-wrapper {
         display: inline-block;
-        width: 72%;
+        width: calc(100% - 32px - 96px);
     }
 
     .button-wrapper {
         float: right;
         display: inline-block;
-        width: 28%;
+        width: 96px;
     }
 
     .header-toggle {
@@ -403,12 +411,21 @@
     /* Bootstrap extra small(xs) responsive breakpoint */
     @media (max-width: 575.98px) {
 
+        .caret-wrapper {
+            float: left;
+            display: inline-block;
+            width: 32px;
+        }
+
         .header-wrapper {
-            width: 88%;
+            display: inline-block;
+            width: calc(100% - 32px - 32px);
         }
 
         .button-wrapper {
-            width: 12%;
+            float: right;
+            display: inline-block;
+            width: 32px;
         }
 
         .card-body {

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -205,43 +205,16 @@
         return this.cardType === 'bg-light' || this.cardType === 'bg-white' || this.cardType === 'bg-warning';
       },
       headerContent () {
+        if (this.isSeamless) {
+            return this.caretHtml + ' ' + this.renderedHeader;
+        }
         return this.renderedHeader;
       },
       altContent () {
         return this.alt && md.render(this.alt) || this.renderedHeader;
       },
       renderedHeader () {
-        let htmlRenderedHeader = md.render(this.header).trim();
-
-        if (this.isSeamless) {
-          // insert the caret to the header content
-          let caretAdded = false;
-
-          // if the header content is wrapped by a <p> or any <h1>, <h2>, ...
-          // then it must be inserted inside these HTML tags, otherwise the
-          // header content will not be in the same line as caret
-          const tags = [
-            ['<p>', '</p>'],
-            ['<h1>', '</h1>'],
-            ['<h2>', '</h2>'],
-            ['<h3>', '</h3>'],
-            ['<h4>', '</h4>'],
-            ['<h5>', '</h5>'],
-            ['<h6>', '</h6>']];
-
-          tags.forEach(header => {
-            if (!caretAdded && htmlRenderedHeader.startsWith(header[0]))  {
-              htmlRenderedHeader = jQuery(htmlRenderedHeader).unwrap().prepend(this.caretHtml + ' ')
-                .wrap(header[0] + header[1]).parent().html();
-              caretAdded = true;
-            }
-          });
-
-          if (!caretAdded) {
-            htmlRenderedHeader = this.caretHtml + ' ' + htmlRenderedHeader;
-          }
-        }
-        return htmlRenderedHeader;
+        return md.renderInline(this.header);
       },
       hasSrc () {
         return this.src && this.src.length > 0;

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -16,7 +16,8 @@
             <div :class="['card-header',{'header-toggle':isExpandableCard}, cardType, borderType]"
                  @click.prevent.stop="isExpandableCard && toggle()"
                  @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
-                <div class="header-wrapper" ref="headerWrapper">
+                <div class="header-wrapper">
+                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-if="showCaret && hasCustomHeader" aria-hidden="true"></span>
                     <slot name="header">
                         <div :class="['card-title', cardType, {'text-white':!isLightBg}]" v-html="headerContent"></div>
                     </slot>
@@ -210,10 +211,6 @@
         return this.alt && md.render(this.alt) || this.renderedHeader;
       },
       renderedHeader () {
-        if (!this.header) {
-          return '';
-        }
-
         let htmlRenderedHeader = md.render(this.header).trim();
 
         if (this.isSeamless) {
@@ -223,10 +220,19 @@
           // if the header content is wrapped by a <p> or any <h1>, <h2>, ...
           // then it must be inserted inside these HTML tags, otherwise the
           // header content will not be in the same line as caret
-          const tags = ['<p>', '<h1>', '<h2>', '<h3>', '<h4>', '<h5>', '<h6>'];
-          tags.forEach(tag => {
-            if (!caretAdded && htmlRenderedHeader.startsWith(tag))  {
-              htmlRenderedHeader = this.insertCaretInsideHeader(htmlRenderedHeader);
+          const tags = [
+            ['<p>', '</p>'],
+            ['<h1>', '</h1>'],
+            ['<h2>', '</h2>'],
+            ['<h3>', '</h3>'],
+            ['<h4>', '</h4>'],
+            ['<h5>', '</h5>'],
+            ['<h6>', '</h6>']];
+
+          tags.forEach(header => {
+            if (!caretAdded && htmlRenderedHeader.startsWith(header[0]))  {
+              htmlRenderedHeader = jQuery(htmlRenderedHeader).unwrap().prepend(this.caretHtml + ' ')
+                .wrap(header[0] + header[1]).parent().html();
               caretAdded = true;
             }
           });
@@ -299,11 +305,6 @@
         if (isOpen && this.hasSrc) {
           this.$refs.retriever.fetch()
         }
-      },
-      insertCaretInsideHeader(originalHeaderHTML) {
-        const wrappedElementName = jQuery(originalHeaderHTML).attr("name");
-        return jQuery(originalHeaderHTML).unwrap().prepend(this.caretHtml + ' ')
-            .wrap(`<${wrappedElementName}></${wrappedElementName}>`).parent().html();
       }
     },
     watch: {
@@ -331,11 +332,6 @@
       this.$nextTick(function () {
         if (this.hasSrc && (this.preloadBool || this.expandedBool)) {
           this.$refs.retriever.fetch()
-        }
-
-        if (this.hasCustomHeader) {
-          this.$refs.headerWrapper.innerHTML =
-            this.insertCaretInsideHeader(this.$refs.headerWrapper.innerHTML);
         }
       });
       const panelHeader = this.$slots.header ? this.$refs.headerWrapper.innerHTML : this.headerContent;

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -35,7 +35,7 @@
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                         </button>
                         <button type="button" :class="['popup-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
-                                v-show="this.popupUrl !== null"
+                                v-show="((this.popupUrl !== null) && (!isSeamless || onHeaderHover))"
                                 @click.stop="openPopup()">
                             <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span>
                         </button>

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -30,7 +30,7 @@
                                       @click.native.stop.prevent="expand()"
                                       @is-open-event="retrieveOnOpen" :is-light-bg="isLightBg"></panel-switch>
                         <button type="button" :class="['close-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
-                                v-show="!isSeamless ? (!noCloseBool) : onHeaderHover"
+                                v-show="isSeamless ? onHeaderHover : (!noCloseBool)"
                                 @click.stop="close()">
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                         </button>

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -17,7 +17,7 @@
                  @click.prevent.stop="isExpandableCard && toggle()"
                  @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
                 <div class="caret-wrapper">
-                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-show="showCaret"></span>
+                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-if="showCaret"></span>
                 </div>
                 <div class="header-wrapper">
                     <slot name="header">

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -17,7 +17,7 @@
                  @click.prevent.stop="isExpandableCard && toggle()"
                  @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
                 <div class="header-wrapper">
-                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-if="showCaret && hasCustomHeader" aria-hidden="true"></span>
+                    <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-show="showCaret"></span>
                     <slot name="header">
                         <div :class="['card-title', cardType, {'text-white':!isLightBg}]" v-html="headerContent"></div>
                     </slot>
@@ -28,12 +28,12 @@
                                       @click.native.stop.prevent="expand()"
                                       @is-open-event="retrieveOnOpen" :is-light-bg="isLightBg"></panel-switch>
                         <button type="button" :class="['close-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
-                                v-show="isSeamless ? onHeaderHover : (!noCloseBool)"
+                                v-show="!isSeamless ? (!noCloseBool) : onHeaderHover"
                                 @click.stop="close()">
                             <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                         </button>
                         <button type="button" :class="['popup-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
-                                v-show="((this.popupUrl !== null) && (!isSeamless || onHeaderHover))"
+                                v-show="this.popupUrl !== null"
                                 @click.stop="openPopup()">
                             <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span>
                         </button>
@@ -205,16 +205,10 @@
         return this.cardType === 'bg-light' || this.cardType === 'bg-white' || this.cardType === 'bg-warning';
       },
       headerContent () {
-        if (this.isSeamless) {
-            return this.caretHtml + ' ' + this.renderedHeader;
-        }
-        return this.renderedHeader;
+        return md.render(this.header);
       },
       altContent () {
-        return this.alt && md.render(this.alt) || this.renderedHeader;
-      },
-      renderedHeader () {
-        return md.renderInline(this.header);
+        return this.alt && md.render(this.alt) || md.render(this.header);
       },
       hasSrc () {
         return this.src && this.src.length > 0;
@@ -225,16 +219,6 @@
         } else {
           return onHeaderHover;
         }
-      },
-      caretHtml () {
-        if (this.localExpanded) {
-          return '<span class="glyphicon glyphicon-chevron-down" aria-hidden="true"></span>'
-        } else {
-          return '<span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>'
-        }
-      },
-      hasCustomHeader () {
-        return this.$slots.header !== undefined;
       }
     },
     data () {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

Fixes MarkBind/markbind#383, fixes MarkBind/markbind#373.

**What is the rationale for this request?**
Fix the seamless panel caret once and for all, by just moving the caret outside the panel header.

**What changes did you make? (Give an overview)**
Since PR #81, carets were inserted inside the header. However, the algorithm for inserting the caret is not perfect, and there were many edge cases. This has lead to many issues as reported as comments in #74
, #81, #83, MarkBind/markbind#373, MarkBind/markbind#383.

Those fixes were unsustainable. Therefore, the relevant PRs have been reverted, and this PR tries a new fix for the original issue.

**Provide some example code that this change will affect:**
NA

**Is there anything you'd like reviewers to focus on?**
Ensuring that the panel rendering did not break.

**Testing instructions:**
1. Compile `vue-strap.min.js` and copy to MarkBind repository.
1. Serve the MarkBind user guide documentation website and check that the panels are OK.
1. Also create a new MarkBind website and try these out in `index.md`:

```
<panel type="seamless" header="Normal">
</panel>

<panel type="seamless" header="# Heading 1">
</panel>

<panel type="seamless" header="## Heading 2">
</panel>

<panel type="seamless" header="### Heading 3">
</panel>

<panel type="seamless" header="#### Heading 4">
</panel>

<panel type="seamless" header="##### Heading 5">
</panel>

<panel type="seamless" header="###### Heading 6">
</panel>

<panel header="Normal panel">
</panel>

<panel header="# Normal panel 2">
</panel>

<panel type="seamless" header="%%Some gray text lalalalalalalalalalalala%%">
</panel>

<panel type="seamless">
  <p slot="header" class="card-title" style="display: inline-block;">
    <i><strong>
      <span style="color:#FF0000;">R  </span>
      <span style="color:#FF7F00;">A  </span>
      <span style="color:#FFFF00;">I  </span>
      <span style="color:#00FF00;">N  </span>
      <span style="color:#0000FF;">B  </span>
      <span style="color:#4B0082;">O  </span>
      <span style="color:#9400D3;">W  </span>
      Custom slot
    </strong></i>
  </p>
</panel>

<panel type="seamless">
<span slot="header" class="card-title">
This header won't break even if I used <code>card-title</code>, hooray!
</span>
</panel>

<panel type="seamless">
<span slot="header">
No breaking as <code>card-title</code> not used, hip hip hooray!
</span>
</panel>

<panel type="seamless" header="Normal seamless">
Normal seamless panel content.
</panel>

<panel type="seamless" header="To websites" popup-url="https://www.yahoo.com">
  Go to website.
</panel>
```