### PR TITLE
Use 'string' library to generate panel header's id

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "markdown-it-mark": "^2.0.0",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
+    "string": "^3.3.3",
     "vue": "^2.0.0"
   },
   "files": [

--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -19,7 +19,7 @@
                 <div class="caret-wrapper">
                     <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-if="showCaret"></span>
                 </div>
-                <div class="header-wrapper">
+                <div class="header-wrapper" ref="headerWrapper">
                     <slot name="header">
                         <div :class="['card-title', cardType, {'text-white':!isLightBg}]" v-html="headerContent"></div>
                     </slot>
@@ -82,6 +82,8 @@
   import panelSwitch from './PanelSwitch.vue'
   import retriever from './Retriever.vue'
 
+  const string = require('string');
+  
   export default {
     components: {
       panelSwitch,
@@ -293,10 +295,17 @@
           this.$refs.retriever.fetch()
         }
       });
-      const panelHeader = this.$slots.header ? this.$refs.headerWrapper.innerHTML : this.headerContent;
-      const panelHeaderText = jQuery(panelHeader).wrap('<div></div>').parent().find(':header').text();
-      if (panelHeaderText) {
-        this.$refs.cardContainer.setAttribute('id', panelHeaderText.trim().replace(/\s+/g, '-').toLowerCase());
+
+      if (this.headerContent) {
+        const panelHeaderText = jQuery(this.headerContent).wrap('<div></div>').parent().find(':header').text();
+        if (panelHeaderText) {
+          this.$refs.cardContainer.setAttribute('id', string(panelHeaderText).slugify().toString());
+        }
+      } else if (this.$refs.headerWrapper.innerHTML) {
+        const header = jQuery(this.$refs.headerWrapper.innerHTML).wrap('<div></div>').parent().find(':header');
+        if (header.length > 0) {
+          this.$refs.cardContainer.setAttribute('id', header[0].id);
+        }
       }
     },
   }


### PR DESCRIPTION
What is the purpose of this pull request? (put "X" next to an item, remove the rest)

• [ ] Documentation update
• [X] Bug fix
• [ ] New feature
• [ ] Enhancement to an existing feature
• [ ] Other, please explain:

Fixes MarkBind/markbind#392.

What is the rationale for this request?
The MarkBind repo is using `markdown-it-anchor` to generate the `id`s for Markdown heading, and it uses the `string` library. For consistency, we should use the same library for vue-strap.

What changes did you make? (Give an overview)
Import the `string` library, use it to generate the ids instead of using our own regex.

Testing instructions:

1. `npm install`
2. run `npm run build` in vue-strap repo
3. copy vue-strap.min.js to markbind repo
4. test on 2103 website.
eg: search "unsafe" 