### PR TITLE
Escape regex in searchbar

### DIFF
--- a/src/Searchbar.vue
+++ b/src/Searchbar.vue
@@ -97,6 +97,9 @@ export default {
               const regex = new RegExp(`(${keyword})`, 'gi');
               let match = regex.exec(value);
               while (match !== null) {
+                if (match.index === regex.lastIndex) {
+                  break;
+                }
                 matchIntervals.push({ start: match.index, end: regex.lastIndex });
                 match = regex.exec(value);
               }

--- a/src/Searchbar.vue
+++ b/src/Searchbar.vue
@@ -89,12 +89,12 @@ export default {
       methods: {
         highlight(value, phrase) {
           function getMatchIntervals() {
-            const keywords = phrase.split(' ')
+            const regexes = phrase.split(' ')
               .filter(keyword => keyword !== '')
-              .map(searchKeyword => searchKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+              .map(searchKeyword => searchKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+              .map(searchKeyword => new RegExp(`(${searchKeyword})`, 'gi'));
             const matchIntervals = [];
-            keywords.forEach((keyword) => {
-              const regex = new RegExp(`(${keyword})`, 'gi');
+            regexes.forEach((regex) => {
               let match = regex.exec(value);
               while (match !== null) {
                 if (match.index === regex.lastIndex) {

--- a/src/Searchbar.vue
+++ b/src/Searchbar.vue
@@ -90,7 +90,7 @@ export default {
         highlight(value, phrase) {
           function getMatchIntervals() {
             const regexes = phrase.split(' ')
-              .filter(keyword => keyword !== '')
+              .filter(searchKeyword => searchKeyword !== '')
               .map(searchKeyword => searchKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
               .map(searchKeyword => new RegExp(`(${searchKeyword})`, 'gi'));
             const matchIntervals = [];

--- a/src/Searchbar.vue
+++ b/src/Searchbar.vue
@@ -18,6 +18,7 @@ export default {
       const matches = [];
       const regexes = this.value.split(' ')
         .filter(searchKeyword => searchKeyword !== '')
+        .map(searchKeyword => searchKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
         .map(searchKeyword => new RegExp(searchKeyword, 'i'));
       this.data.forEach((entry) => {
         const { headings, src, title } = entry;
@@ -88,7 +89,9 @@ export default {
       methods: {
         highlight(value, phrase) {
           function getMatchIntervals() {
-            const keywords = phrase.split(' ').filter(keyword => keyword !== '');
+            const keywords = phrase.split(' ')
+              .filter(keyword => keyword !== '')
+              .map(searchKeyword => searchKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
             const matchIntervals = [];
             keywords.forEach((keyword) => {
               const regex = new RegExp(`(${keyword})`, 'gi');


### PR DESCRIPTION
Fixes markbind/markbind#427

Keyword strings are escaped correctly:

![image](https://user-images.githubusercontent.com/19278089/46915439-7193c880-cfde-11e8-99f5-536da2e325ca.png)

The problem wasn't actually that too many headers were being matched, it was caused by the highlighting function:

![image](https://user-images.githubusercontent.com/19278089/46915428-44471a80-cfde-11e8-9165-2242b6d3f203.png)

Apparently `regex.exec` has an issue where zero length matches don't advance the match, so it loops forever.

Since matching too many headers wasn't the problem, we can actually consider supporting regex within the searchbar. Is there a use case for this?

