### PR TITLE
Upgrade anchor ID generation

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -81,8 +81,6 @@
   import md from './utils/markdown.js'
   import panelSwitch from './PanelSwitch.vue'
   import retriever from './Retriever.vue'
-
-  const string = require('string');
   
   export default {
     components: {
@@ -296,10 +294,11 @@
         }
       });
 
+      const slugify = (s) => encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'))
       if (this.headerContent) {
         const panelHeaderText = jQuery(this.headerContent).wrap('<div></div>').parent().find(':header').text();
         if (panelHeaderText) {
-          this.$refs.cardContainer.setAttribute('id', string(panelHeaderText).slugify().toString());
+          this.$refs.cardContainer.setAttribute('id', slugify(panelHeaderText));
         }
       } else if (this.$refs.headerWrapper.innerHTML) {
         const header = jQuery(this.$refs.headerWrapper.innerHTML).wrap('<div></div>').parent().find(':header');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Fixes MarkBind/markbind#413

**What is the rationale for this request?**
Anchor ID generation for vue-strap is different from MarkBind. It needs to be updated to match the one in MarkBind.

**What changes did you make? (Give an overview)**
Changed the anchor generation by following the implementation in [`markbind-it-anchor@5.0.0`](https://github.com/valeriangalliat/markdown-it-anchor/blob/v5.0.0/index.js#L1).

`markbind-it-anchor` used to use the `strings` package, which is why the original code for `Panel.vue` uses that as well. We are substituting it with the one found in version `5.0.0` because that is what the `MarkBind` side is currently using.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```html
<panel header="## Header:, with comma" expand>
  Panel content
</panel>
```

**Is there anything you'd like reviewers to focus on?**
NIL

**Testing instructions:**
1. `npm run build`.
2. Copy `vue-strap.min.js` to your `MarkBind` `asset/js`.
3. Init a new website with the example code above.
4. Test that the anchor URL jumping works (the url should be of this form:

```
http://127.0.0.1:8080/#header%3A%2C-with-comma
```