### PR TITLE
Panel: do not decamelize anchor headings

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -299,7 +299,7 @@
       if (this.headerContent) {
         const panelHeaderText = jQuery(this.headerContent).wrap('<div></div>').parent().find(':header').text();
         if (panelHeaderText) {
-          this.$refs.cardContainer.setAttribute('id', slugify(panelHeaderText));
+          this.$refs.cardContainer.setAttribute('id', slugify(panelHeaderText, { decamelize: false }));
         }
       } else if (this.$refs.headerWrapper.innerHTML) {
         const header = jQuery(this.$refs.headerWrapper.innerHTML).wrap('<div></div>').parent().find(':header');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of MarkBind/markbind#667.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
In MarkBind/markbind#667, we disabled decamelization for anchor headings to retain compatibility with GFMD. We should also make the same change in vue-strap to generate consistent headers for headings in panels.

**What changes did you make? (Give an overview)**
I modified the call to `slugify()` when generating anchors for panel headings to always set `decamelize: false`.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```vue
<panel header="# Heading with camelCase and PascalCase">
Panel content
</panel>
```

**Testing instructions:**
1. `npm run build.`
2. Copy `vue-strap.min.js` into the MarkBind's `asset/js`.
3. Create a new MarkBind project and add the example code above.
4. `markbind serve` and check that the panel `id` is `heading-with-camelcase-and-pascalcase`, without decamelization.