### PR TITLE
Seamless panels: omit caret if not expandable

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -83,7 +83,7 @@
   import retriever from './Retriever.vue'
 
   const slugify = require('@sindresorhus/slugify');
-  
+
   export default {
     components: {
       panelSwitch,
@@ -177,7 +177,7 @@
         return this.expandableBool;
       },
       showCaret () {
-        return this.isSeamless;
+        return this.isSeamless && this.expandableBool;
       },
       isSeamless () {
         return this.type === 'seamless';


### PR DESCRIPTION
Fixes https://github.com/MarkBind/markbind/issues/369

### Before
<img width="920" alt="screenshot 2019-02-07 at 3 57 29 pm" src="https://user-images.githubusercontent.com/9073504/52397612-189df200-2af1-11e9-838f-807b27d83dd9.png">


### After
<img width="912" alt="screenshot 2019-02-07 at 3 48 10 pm" src="https://user-images.githubusercontent.com/9073504/52397495-bd6bff80-2af0-11e9-9e8c-ad95ea1420c7.png">