### PR TITLE
Use a simpler :prefix-name: syntax for icon fonts in <panel> headings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4986,6 +4986,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-mark/-/markdown-it-mark-2.0.0.tgz",
       "integrity": "sha1-RqGqlHEFrtgYiXjgoBYXnkBPQsc="
     },
+    "markdown-it-regexp": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-regexp/-/markdown-it-regexp-0.4.0.tgz",
+      "integrity": "sha1-1k1xPuzsVc5M/esyF1DswJniwtw="
+    },
     "markdown-it-sub": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/markdown-it-sub/-/markdown-it-sub-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "markdown-it-imsize": "^2.0.1",
     "markdown-it-ins": "^2.0.0",
     "markdown-it-mark": "^2.0.0",
+    "markdown-it-regexp": "^0.4.0",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
     "string": "^3.3.3",

--- a/src/utils/markdown-it-icons.js
+++ b/src/utils/markdown-it-icons.js
@@ -1,0 +1,13 @@
+module.exports = require('markdown-it-regexp')(
+    /:(fa[brs]|glyphicon)-([a-z-]+):/m,
+    (match, utils) => {
+        let iconFontType = match[1];
+        let iconFontName = match[2];
+
+        if (iconFontType === 'glyphicon') {
+            return `<span aria-hidden="true" class="glyphicon glyphicon-${iconFontName}"></span>`;
+        } else { // If icon is a Font Awesome icon
+            return `<span aria-hidden="true" class="${iconFontType} fa-${iconFontName}"></span>`;
+        }
+    }
+);

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -9,9 +9,10 @@ markdownIt.use(require('markdown-it-mark'))
   .use(require('markdown-it-sup'))
   .use(require('markdown-it-mark'))
   .use(require('./markdown-it-dimmed'))
+  .use(require('./markdown-it-icons'))
   .use(require('markdown-it-imsize'), {
     autofill: false
-  })
+  });
 
 // fix emoji numbers
 const emojiData = require('markdown-it-emoji/lib/data/full.json');


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Bug fix

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->
Part of MarkBind/markbind#680.

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
In MarkBind/markbind#680, we added a new `:prefix-name:` syntax for icon fonts. Since this syntax is parsed in `markdown-it`, we should make the same changes to `markdown-it` as we did in MarkBind/markbind#680 to ensure that panel headings with icon fonts are also parsed correctly.

**What changes did you make? (Give an overview)**
I added [`markdown-it-regexp`](https://github.com/rlidwka/markdown-it-regexp) to match `:prefix-name:` and replace them with the appropriate icon font HTML.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```vue
<panel header=":far-list-alt: :glyphicon-home: Heading with icon fonts">
Panel content
</panel>
```

**Testing instructions:**
1. `npm run build.`
2. Copy `vue-strap.min.js` into the MarkBind's `asset/js`.
3. Create a new MarkBind project and add the example code above.
4. `markbind serve` and check that the panel heading renders with the appropriate icons:
![Panel heading with font icons](https://user-images.githubusercontent.com/1782590/52460010-4cd1eb00-2ba3-11e9-848b-ba21b70f88c4.png)

