### PR TITLE
Searchbar: Add algolia key

### DIFF
--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -1,6 +1,7 @@
 <template>
   <div style="position: relative">
     <input type="text" class="form-control"
+      :id="inputId"
       :placeholder="placeholder"
       autocomplete="off"
       v-model="value"
@@ -67,7 +68,12 @@ export default {
     menuAlignRight: {
       type: Boolean,
       default: false
+    },
+    algolia: {
+      type: Boolean,
+      default: false
     }
+
   },
   data () {
     return {
@@ -78,6 +84,9 @@ export default {
     }
   },
   computed: {
+    inputId () {
+      return this.algolia ? "algolia-search-input" : null;
+    },
     primitiveData () {
       if (this.data) {
         return this.data.filter(value => {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

Part of [MarkBind/markbind#691](https://github.com/MarkBind/markbind/pull/691).

**What is the rationale for this request?**
We want the user to be able to easily use Algolia results with the `searchbar` component.

**What changes did you make? (Give an overview)**
Add the `algolia` key to the `searchbar` component. A user who wants the `searchbar` to use Algolia results can simply add the `algolia` key when defining the `searchbar`.

This works by adding the `algolia-search-input` id to the `input`, which will be used by the `algolia` initialisation code in Markbind's `page.ejs`.

**Provide some example code that this change will affect:**

```
<searchbar placeholder="Search" algolia menu-align-right></searchbar>
```

**Testing instructions:**
The component 
```
<searchbar placeholder="Search" algolia menu-align-right></searchbar>
```
should have the id `algolia-search-input` added to the `input` element.