### PR TITLE
Remove position fixed classes from Navbar

### DIFF
--- a/src/Navbar.vue
+++ b/src/Navbar.vue
@@ -4,9 +4,7 @@
     'navbar-dark':(type === 'inverse'),
     'navbar-light':(type === 'default'),
     'bg-dark':(type === 'inverse'),
-    'bg-light':(type === 'default'),
-    'fixed-top':(placement === 'top'),
-    'fixed-bottom':(placement === 'bottom')
+    'bg-light':(type === 'default')
   }, addClass]">
     <div class="container-fluid">
       <div class="navbar-brand"><slot name="brand"></slot></div>
@@ -35,10 +33,6 @@ export default {
     type: {
       type: String,
       default: 'default'
-    },
-    placement: {
-      type: String,
-      default: ''
     },
     addClass: {
       type: String,
@@ -87,14 +81,6 @@ export default {
     }).onBlur(e => {
       if (!this.$el.contains(e.target)) { this.collapsed = true }
     })
-    let height = this.$el.offsetHeight
-    if (this.placement === 'top') {
-      document.body.style.paddingTop = height + 'px'
-      $(window).on('hashchange', () => scrollBy(0, -height))
-    }
-    if (this.placement === 'bottom') {
-      document.body.style.paddingBottom = height + 'px'
-    }
     if (this.slots.collapse) $('[data-toggle="collapse"]',this.$el).on('click', (e) => this.toggleCollapse(e))
   },
   beforeDestroy () {
@@ -106,7 +92,7 @@ export default {
 
 <style scoped>
 @media (max-width: 767px) {
-  .navbar-fixed-top .navbar-collapse {
+  .navbar-collapse {
     max-height: 80vh !important;
     overflow-x: hidden !important;
     overflow-y: scroll !important;

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -100,7 +100,7 @@ export default {
       return 'typeaheadTemplate';
     },
     dropdownMenuClasses () {
-      return ['dropdown-menu', 'search-dropdown-menu', {show: this.showDropdown},
+      return ['dropdown-menu', 'page-front', 'search-dropdown-menu', {show: this.showDropdown},
         {'dropdown-menu-right': this.menuAlignRight}];
     }
   },
@@ -161,6 +161,9 @@ export default {
 </script>
 
 <style>
+.page-front {
+  z-index: 1030;
+}
 .dropdown-menu > li > a {
   cursor: pointer;
 }


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix
• [x] Other, please explain: Change behaviour of Navbar to be consistent with Holy Grail Layout

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Part of MarkBind/markbind#733 and MarkBind/markbind#790

**Bug report**
- Currently, the page navigation has a high z-index from its Bootstrap classes. This causes the dropdown menu from the search bar (typeahead) to be placed behind the page navigation.

**What changes did you make? (Give an overview)**
- Remove support for `placement prop` within Navbar.vue
- Remove `.navbar-fixed-top` CSS class name
- Add `page-front` class for dropdown menu within `Typeahead.vue`
