### PR TITLE
Increase z-index of dropdown menu

### DIFF
--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -65,7 +65,7 @@ export default {
       return [{disabled: this.disabledBool}, this.class, this.isLi ? 'dropdown' : 'btn-group', this.addClass]
     },
     menuClasses() {
-      return [{show: this.showBool}, {'dropdown-menu-right': this.menuAlignRight}];
+      return ['page-front', {show: this.showBool}, {'dropdown-menu-right': this.menuAlignRight}];
     },
     disabledBool() {
       return toBoolean(this.disabled);
@@ -141,6 +141,10 @@ export default {
 </script>
 
 <style scoped>
+.page-front {
+  z-index: 1030;
+}
+
 .secret {
   position: absolute;
   clip: rect(0 0 0 0);


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes https://github.com/MarkBind/markbind/issues/802

**Bug report**

Similar to in #101, the dropdown menu has z-index lower than that of the page navigations. This causes the page navigation to overlap with the dropdown menu, and makes the dropdown menu unclickable.

**What changes did you make? (Give an overview)**

Raise z-index of dropdown menu to ensure that it is positioned on top of the page navigation.