### PR TITLE
Remove page-front class from dropdown and typeahead

### DIFF
--- a/src/Dropdown.vue
+++ b/src/Dropdown.vue
@@ -65,7 +65,7 @@ export default {
       return [{disabled: this.disabledBool}, this.class, this.isLi ? 'dropdown' : 'btn-group', this.addClass]
     },
     menuClasses() {
-      return ['page-front', {show: this.showBool}, {'dropdown-menu-right': this.menuAlignRight}];
+      return [{show: this.showBool}, {'dropdown-menu-right': this.menuAlignRight}];
     },
     disabledBool() {
       return toBoolean(this.disabled);
@@ -141,10 +141,6 @@ export default {
 </script>
 
 <style scoped>
-.page-front {
-  z-index: 1030;
-}
-
 .secret {
   position: absolute;
   clip: rect(0 0 0 0);

--- a/src/Typeahead.vue
+++ b/src/Typeahead.vue
@@ -100,7 +100,7 @@ export default {
       return 'typeaheadTemplate';
     },
     dropdownMenuClasses () {
-      return ['dropdown-menu', 'page-front', 'search-dropdown-menu', {show: this.showDropdown},
+      return ['dropdown-menu', 'search-dropdown-menu', {show: this.showDropdown},
         {'dropdown-menu-right': this.menuAlignRight}];
     }
   },
@@ -161,9 +161,6 @@ export default {
 </script>
 
 <style>
-.page-front {
-  z-index: 1030;
-}
 .dropdown-menu > li > a {
   cursor: pointer;
 }


### PR DESCRIPTION
The page-front class was added in #103 and #101 to increase the z-index in order to fix the issue of them being positioned below the page navigations after changes in https://github.com/MarkBind/markbind/pull/733.

The root cause of the page navigations being positioned above the dropdown and typeahead has been identified to be the sticky-top class added to the page navigations which increases the z-index unnecessarily. The sticky-top class will be removed from the side navigations in https://github.com/MarkBind/markbind/pull/827.

Let's remove the page-front class from the dropdown and typeahead components now that they are no longer necessary.