### PR TITLE
Cache panel contents after first load

### DIFF
--- a/src/Panel.vue
+++ b/src/Panel.vue
@@ -42,25 +42,10 @@
                     </slot>
                 </div>
             </div>
-            <template v-if="preloadBool">
+            <template v-if="preloadBool || isCached">
                 <div class="card-collapse"
                      ref="panel"
                      v-show="localExpanded"
-                >
-                    <div class="card-body">
-                        <slot></slot>
-                        <retriever v-if="hasSrc" ref="retriever" :src="src" :fragment="fragment" delay></retriever>
-                        <panel-switch v-show="isExpandableCard && bottomSwitchBool" :is-open="localExpanded"
-                                      @click.native.stop.prevent="collapseThenScrollIntoViewIfNeeded()"
-                                      @is-open-event="retrieveOnOpen"></panel-switch>
-                    </div>
-                    <hr v-show="isSeamless" />
-                </div>
-            </template>
-            <template v-else>
-                <div class="card-collapse"
-                     ref="panel"
-                     v-if="localExpanded"
                 >
                     <div class="card-body">
                         <slot></slot>
@@ -229,7 +214,8 @@
       return {
         onHeaderHover: false,
         localExpanded: false,
-        localMinimized: false
+        localMinimized: false,
+        isCached: false
       }
     },
     methods: {
@@ -270,6 +256,15 @@
     },
     watch: {
       'localExpanded': function (val, oldVal) {
+        if (this.isCached) {
+        	return;
+        }
+        /* When either one of the values is true,
+         * it means that the data is/will be cached.
+         */
+        if (val || oldVal) {
+          this.isCached = true;
+        }
         this.$nextTick(function () {
           this.retrieveOnOpen(this, val);
         })


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

- Fixes https://github.com/MarkBind/markbind/issues/868
- Fixes https://github.com/MarkBind/markbind/issues/483
- Fixes https://github.com/MarkBind/markbind/issues/872

**What is the rationale for this request?**

Content in panels are rerendered on each open, causing the above mentioned issues.

**What changes did you make? (Give an overview)**

Cache the rendered content on first load, then reuse it thereafter.

**Provide some example code that this change will affect:**

```
<panel header = "inner"><panel header = "inner"><panel header = "inner">
innermost
</panel></panel></panel>
```

Should now remember its nested state upon reopening of outermost panel.

**Testing instructions:**

Test that content is not recreated (e.g. input elements maintain their text) every time a panel is toggled open.