### PR TITLE
Add attribute to allow vertical centering of panels

### DIFF
--- a/src/Modal.vue
+++ b/src/Modal.vue
@@ -6,7 +6,7 @@
       'fade':effect === 'fade',
       'zoom':effect === 'zoom'
     }, addClass]">
-    <div v-bind:class="{'modal-dialog':true,'modal-lg':largeBool,'modal-sm':smallBool}" role="document"
+    <div v-bind:class="{'modal-dialog':true,'modal-lg':largeBool,'modal-sm':smallBool,'modal-dialog-centered':centerBool}" role="document"
       v-bind:style="{width: optionalWidth}">
       <div class="modal-content">
         <slot name="modal-header">
@@ -66,6 +66,10 @@ export default {
       type: Boolean,
       default: false
     },
+    center: {
+      type: Boolean,
+      default: false
+    },
     name: {
       type: String
     },
@@ -91,6 +95,9 @@ export default {
     },
     smallBool () {
       return toBoolean(this.small)
+    },
+    centerBool () {
+      return toBoolean(this.center)
     },
     titleRendered () {
       return md.renderInline(this.title);


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Fixes Markbind/markbind#865

**What is the rationale for this request?**
Users may want to center their modals.

**What changes did you make? (Give an overview)**
Added an attribute that makes modals appear in center.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```html

More about <trigger for="modal:trigger_id">modals</trigger>.
<modal title="Modal" id="modal:trigger_id" center>
   Modals are centered.
</modal>

This should make the modal appear in the center.

```

**Is there anything you'd like reviewers to focus on?**
Suggestions for the attribute name other than center?

**Testing instructions:**
Run it and see if modals appear in center of page.
