### PR TITLE
Delay popover close when trigger is hover

### DIFF
--- a/src/Popover.vue
+++ b/src/Popover.vue
@@ -1,16 +1,16 @@
 <template>
   <span :class="[addClass]">
-    <span ref="trigger" v-if="hasSlot" v-on:click="false"><slot></slot></span><!--
+    <span ref="trigger" v-if="hasSlot"><slot></slot></span><!--
     -->
     <transition :name="effect">
     <div ref="popover" v-if="show"
       :class="['popover', popoverPlacementClass]">
       <div class="arrow" ref="arrow"></div>
-      <h3 class="popover-header" v-if="title" v-on:click="false">
+      <h3 class="popover-header" v-if="title">
         <slot name="title" v-if="hasTitleSlot"></slot>
         <span v-else v-html="titleRendered"></span>
       </h3>
-      <div class="popover-body" v-on:click="false">
+      <div class="popover-body">
         <slot name="content" v-if="hasContentSlot"></slot>
         <span v-else v-html="contentRendered"></span>
       </div>

--- a/src/Tooltip.vue
+++ b/src/Tooltip.vue
@@ -1,12 +1,12 @@
 <template>
   <span :class="[addClass]">
-    <span ref="trigger" v-on:click="false"><slot></slot></span><!--
+    <span ref="trigger"><slot></slot></span><!--
     --><transition :name="effect">
       <div ref="popover" v-if="show" style="display:block;"
         :class="['tooltip', tooltipPlacementClass, 'show']"
       >
         <div class="arrow" ref="arrow"></div>
-        <div class="tooltip-inner" v-on:click="false">
+        <div class="tooltip-inner">
           <span name="content" v-html="contentRendered"></span>
        </div>
       </div>

--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -11,6 +11,8 @@ function getFirstChild(node) {
   return node && (node.children.length ? node.children[0] : node)
 }
 
+const POPOVER_TIMEOUT = 200
+
 export default {
   props: {
     trigger: {
@@ -41,7 +43,8 @@ export default {
         left: 0
       },
       isPopover: false,
-      show: false
+      show: false,
+      delayTimeout: null
     }
   },
   computed: {
@@ -58,11 +61,32 @@ export default {
         trigger.setTriggerBy(this)
       }
     },
+    clearTimeout() {
+      clearTimeout(this.delayTimeout)
+      this.delayTimeout = null
+    },
     toggle (e) {
       let trigger = getFirstChild(this.$refs.trigger)
       if (e && this.trigger === 'contextmenu' && trigger === e.target) e.preventDefault()
-      if (!(this.show = !this.show)) {
+      if (this.show) {
+        if (e.type === 'mouseleave') {
+          // Only delay closing for hover events
+          this.delayTimeout = setTimeout(() => {
+            this.show = false
+            this.clearTimeout()
+          }, POPOVER_TIMEOUT)
+        } else if (e.type === 'mouseenter') {
+          // If user hovers back, cancel the close
+          this.clearTimeout()
+        } else {
+          // Otherwise, it's another trigger and we close it immediately
+          this.clearTimeout()
+          this.show = false;
+        }
         return
+      } else {
+        this.clearTimeout()
+        this.show = true
       }
       if (e) {
         let target = e.target


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [x] Enhancement to an existing feature

**What is the rationale for this request?**

See https://github.com/MarkBind/markbind/pull/885.

It would be good to add a delay to the popover closing, so that users can hover over it and select/copy content as they wish.

**What changes did you make? (Give an overview)**

Don't close the popover when the mouse leaves the trigger immediately, instead it is delayed by 200ms. If the mouse moves over another trigger to the same popover the closing is cancelled.

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
More about <trigger for="pop:trigger_id">trigger</trigger>.
<popover id="pop:trigger_id" content="This popover is triggered by a trigger"></popover>
<br>
This is the same <trigger for="pop:trigger_id">trigger</trigger> as last one.
```

Example code from the component guide. Moving your mouse between the two triggers should result in the popover being kept open.

Link: https://5cf0bb9e974fcb0008ed6b17--markbind-master.netlify.com/userguide/usingcomponents#popovers

Similarly, for footnotes, you can hover over the footnote and the popover won't close:
https://5cf0bb9e974fcb0008ed6b17--markbind-master.netlify.com/userguide/markbindsyntaxoverview#markbind-extensions-to-markdown

Expand the panel and scroll down to the footnotes section.


**Is there anything you'd like reviewers to focus on?**

Try and make the popover fail to appear/fail to close

**Testing instructions:**

Make multiple triggers, hover over them and try to get a bug to occur?

Make sure that the other triggers like click and contextmenu aren't affected.