### PR TITLE
Add `dismissible` attribute to Box

### DIFF
--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -1,11 +1,14 @@
 <template>
-    <div class="alert container" :class="[boxStyle, addClass]" :style="customStyle">
+    <div class="alert container" :class="[boxStyle, addClass, {'alert-dismissible': dismissible}]" :style="customStyle">
         <div class="icon-wrapper" v-if="!isDefault">
             <span v-html="iconType"></span>
         </div>
         <div class="contents">
             <slot></slot>
         </div>
+        <button type="button" class="close" data-dismiss="alert" aria-label="Close" v-if="dismissible">
+          <span aria-hidden="true">&times;</span>
+        </button>
     </div>
 </template>
 
@@ -13,6 +16,10 @@
   import md from './utils/markdown.js'
   export default {
     props: {
+      dismissible: {
+        type: Boolean,
+        default: false
+      },
       backgroundColor: {
         type: String,
         default: null


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
• [x] Enhancement to an existing feature

Related [PR](https://github.com/MarkBind/markbind/pull/884)

**What is the rationale for this request?**
We can enhance the Box feature to allow the boxes to be closed.

**What changes did you make? (Give an overview)**
Added a `dismissible` attribute to `<box>` that adds a close button to the Box.

**Provide some example code that this change will affect:**
```html
<box type="info" dismissible>
Info box
</box>
```

**Is there anything you'd like reviewers to focus on?**
-

**Testing instructions:**
The user guide section in the netlify preview contains an example that demonstrates the `dismissible` attribute.

**Proposed commit message: (wrap lines at 72 characters)**
Let's enhance the Box feature by adding support for a `dismissible` 
attribute, which adds a close button to the box.
