### PR TITLE
Fix stray space after tool-tipped text

### DIFF
--- a/src/Tooltip.vue
+++ b/src/Tooltip.vue
@@ -1,8 +1,7 @@
 <template>
   <span :class="[addClass]">
     <span ref="trigger" v-on:click="false"><slot></slot></span><!--
-    -->
-    <transition :name="effect">
+    --><transition :name="effect">
       <div ref="popover" v-if="show" style="display:block;"
         :class="['tooltip', tooltipPlacementClass, 'show']"
       >
@@ -11,8 +10,8 @@
           <span name="content" v-html="contentRendered"></span>
        </div>
       </div>
-    </transition>
-  </span>
+    </transition><!--
+  --></span>
 </template>
 
 <script>


### PR DESCRIPTION
Fixes [Markbind#569](https://github.com/MarkBind/markbind/issues/569)

Related [PR on Markbind](https://github.com/MarkBind/markbind/pull/886)

Currently, there is a bug where there will be an extra space after a tool-tipped text.

Let's fix that by removing the newline characters in the Vue template