### PR TITLE
Refactor trigger to style text only if no add-class

### DIFF
--- a/src/trigger.vue
+++ b/src/trigger.vue
@@ -1,5 +1,5 @@
 <template>
-    <span ref="trigger" :class="[addClass]"><slot></slot></span>
+    <span ref="trigger" :class="[addClass || (this.trigger === 'click' ? 'click-trigger' : 'other-trigger')]"><slot></slot></span>
 </template>
 
 <script>
@@ -31,15 +31,6 @@
         }
         this._triggerBy && this._triggerBy.toggle(e)
       })
-
-      if (this.trigger === 'click') {
-        this.$refs.trigger.style['cursor'] = 'pointer'
-        this.$refs.trigger.style['-webkit-text-decoration'] = 'underline dashed';
-        this.$refs.trigger.style['text-decoration'] = 'underline dashed';
-      } else {
-        this.$refs.trigger.style['-webkit-text-decoration'] = 'underline dotted';
-        this.$refs.trigger.style['text-decoration'] = 'underline dotted'
-      }
     },
     methods: {
       setTriggerBy (vm) {
@@ -50,5 +41,11 @@
 </script>
 
 <style>
-
+    .click-trigger {
+        cursor: pointer;
+        text-decoration: underline dashed;
+    }
+    .other-trigger {
+        text-decoration: underline dotted;
+    }
 </style>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

**What is the rationale for this request?**

It is hard to add custom styles to trigger elements, as trigger sets the style attribute directly. Let's only add the custom underline style to triggers only when the add-class attribute is not specified, so that users can provide their own classes.

**What changes did you make? (Give an overview)**

Refactored the underline styles into classes, and then only add the relevant class if add-class attribute is not specified.
