### PR TITLE
Enhance popovers to allow hovering over them

### DIFF
--- a/src/utils/popoverMixins.js
+++ b/src/utils/popoverMixins.js
@@ -34,6 +34,10 @@ export default {
     },
     id: {
       type: String
+    },
+    hoverable: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -53,6 +57,9 @@ export default {
     },
     titleRendered () {
       return md.renderInline(this.title)
+    },
+    hoverableBool() {
+      return toBoolean(this.hoverable)
     }
   },
   methods: {
@@ -131,6 +138,9 @@ export default {
         }
         // temporary fix for popover going off screen - end
 
+        if (this.hoverableBool) {
+          $(this.$refs.popover).on('mouseleave mouseenter', this.toggle)
+        }
       }, 20)
     },
     calculateOffset (trigger, popover) {


### PR DESCRIPTION
It is hard to interact with popovers and tooltips, since they disappear
once hovered over.

Let's add a new attribute 'hoverable' to popoverMixins.

If true, once the popover is loaded the popover itself will listen to
the hover (mouseenter and mouseleave) events just like a trigger.