### PR TITLE
Add light style to box

### DIFF
--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -1,9 +1,9 @@
 <template>
-    <div class="alert container" :class="[boxStyle, addClass]" :style="customStyle">
+    <div class="alert container" :class="[boxStyle, addClass, lightStyle]" :style="customStyle">
         <div v-if="!isDefault" class="icon-wrapper">
             <span v-html="iconType"></span>
         </div>
-        <div class="contents">
+        <div class="contents" :class="fontBlack">
             <h6 v-if="heading" class="heading">{{ heading }}</h6>
             <button v-if="dismissible" type="button" class="close dismiss-button" data-dismiss="alert" aria-label="Close">
                 <span aria-hidden="true">&times;</span>
@@ -16,6 +16,7 @@
 
 <script>
   import md from './utils/markdown.js'
+
   export default {
     props: {
       dismissible: {
@@ -53,6 +54,10 @@
       heading: {
         type: String,
         default: null,
+      }, 
+      light: {
+        type: Boolean,
+        default: false,
       }
     },
     computed: {
@@ -76,6 +81,26 @@
             return 'alert-default'
         }
       },
+      lightStyle() {
+        if (this.light) {
+            switch (this.type) {
+            case 'warning':
+                return 'border-warning text-warning alert-border-left';
+            case 'info':
+            case 'definition':
+                return 'border-info text-info alert-border-left';
+            case 'success':
+            case 'tip':
+                return 'border-sucess text-success alert-border-left';
+            case 'important':
+            case 'wrong':
+                return 'border-danger text-danger alert-border-left';
+            default:
+                return '';
+            }
+        }
+        return '';
+      },
       customStyle() {
         var style = {};
         if (this.backgroundColor) {
@@ -92,6 +117,12 @@
           style.color = this.color;
         }
         return style;
+      },
+      fontBlack() {
+        if (this.light) {
+          return 'font-black';
+        }
+        return '';
       },
       iconType() {
         if (this.icon) {
@@ -167,5 +198,15 @@
         color: #24292e;
         background-color: #f6f8fa;
         border-color: #e8ebef;
+    }
+    
+    .alert-border-left {
+        background-color: #f9f8f8;
+        border-left: solid;
+        border-width: 0px 0px 0px 5px;
+    }
+        
+    .font-black {
+        color: #24292e;
     }
 </style>


### PR DESCRIPTION
Using Markbind's PR template cos there isn't one for vue-strap

**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Fixes https://github.com/MarkBind/markbind/issues/909

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**
Requested enhancement

**What changes did you make? (Give an overview)**
I added an additional prop to box called `light` that allows the user to make the tipbox lighter by about 20%

**Provide some example code that this change will affect:**

<!-- Paste the example code below: -->
```js
// Current
<box type="success">
    success
</box>

// Light
<box type="success" light>
    success light
</box>
```

**Is there anything you'd like reviewers to focus on?**
I am terrible at colors and would appreciate any ideas on the color scheme I chose.

Also, I do not think that the colors should be defined in the `Tipbox.vue` file itself as colors should be consistent across the repo. Any suggestions on where I should define the light color constants?

**Testing instructions:**
Same as DG of Markbind.

**Proposed commit message: (wrap lines at 72 characters)**
Adds a light style to TipBox via an additional prop

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->

**Screenshots**
**Before (19.5%)**
<img width="787" alt="Screen Shot 2020-01-03 at 10 52 11 PM" src="https://user-images.githubusercontent.com/28432397/71882578-b241a980-316f-11ea-8a1e-e7dda9102085.png">



**After change (36%)**
<img width="880" alt="Screen Shot 2020-01-07 at 5 01 38 PM" src="https://user-images.githubusercontent.com/28432397/71882481-845c6500-316f-11ea-8425-00f4a8f28b75.png">

