### PR TITLE
TipBox.vue: Support different size icons 

### DIFF
--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -12,7 +12,6 @@
             </button>
             <slot></slot>
         </div>
-
     </div>
 </template>
 
@@ -29,6 +28,10 @@
         default: null
       },
       borderColor: {
+        type: String,
+        default: null
+      },
+      iconSize: {
         type: String,
         default: null
       },
@@ -193,10 +196,6 @@
     }
 
     .contents {
-        display: flex;
-        flex-direction: column;
-        justify-content: center;
-        align-content: center;
         padding: 0 6px;
         width: 100%;
     }

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -40,6 +40,22 @@
         type: String,
         default: null
       },
+      icon: {
+        type: String,
+        default: null
+      },
+      isExtraLarge: {
+        type: Boolean,
+        default: false
+      },
+      iconLarge: {
+        type: Boolean,
+        default: false
+      },
+      iconMedium: {
+        type: Boolean,
+        default: false
+      },
       type: {
         type: String,
         default: 'none'
@@ -186,11 +202,11 @@
     .icon-wrapper {
         display: flex;
         margin-right: .5em;
-        width: 22px;
-        height: 22px;
     }
 
     .contents {
+        display: flex;
+        align-items: center;
         padding: 0 6px;
         width: 100%;
     }
@@ -209,5 +225,17 @@
         
     .font-black {
         color: #24292e;
+    }
+
+    .icon-extra-large {
+      font-size: 4em;
+    }
+
+    .icon-large {
+      font-size: 3em;
+    }
+
+    .icon-medium {
+      font-size: 2em;
     }
 </style>

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -197,7 +197,6 @@
         flex-direction: column;
         justify-content: center;
         align-content: center;
-        font-size: medium;
         padding: 0 6px;
         width: 100%;
     }

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="alert container" :class="[boxStyle, addClass, lightStyle]" :style="customStyle">
-        <div v-if="!isDefault" class="icon-wrapper">
+        <div v-if="!isDefault" class="icon-wrapper" :class="[iconStyle]">
             <slot name="_icon">
                 <span v-html="iconType"></span>
             </slot>
@@ -154,8 +154,13 @@
           default:
             return '<i class="fas fa-exclamation"></i>';
         }
+      }, 
+      iconStyle() {
+        if (this.iconSize) {
+          return `fa-${this.iconSize}`;
       }
     }
+  }
   }
 </script>
 

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -31,10 +31,6 @@
         type: String,
         default: null
       },
-      iconSize: {
-        type: String,
-        default: null
-      },
       borderLeftColor: {
         type: String,
         default: null
@@ -44,6 +40,10 @@
         default: null
       },
       icon: {
+        type: String,
+        default: null
+      },
+      iconSize: {
         type: String,
         default: null
       },

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -44,18 +44,6 @@
         type: String,
         default: null
       },
-      isExtraLarge: {
-        type: Boolean,
-        default: false
-      },
-      iconLarge: {
-        type: Boolean,
-        default: false
-      },
-      iconMedium: {
-        type: Boolean,
-        default: false
-      },
       type: {
         type: String,
         default: 'none'
@@ -206,7 +194,10 @@
 
     .contents {
         display: flex;
-        align-items: center;
+        flex-direction: column;
+        justify-content: center;
+        align-content: center;
+        font-size: medium;
         padding: 0 6px;
         width: 100%;
     }

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -158,9 +158,10 @@
       iconStyle() {
         if (this.iconSize) {
           return `fa-${this.iconSize}`;
+        }
+        return '';
       }
     }
-  }
   }
 </script>
 

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -217,16 +217,4 @@
     .font-black {
         color: #24292e;
     }
-
-    .icon-extra-large {
-      font-size: 4em;
-    }
-
-    .icon-large {
-      font-size: 3em;
-    }
-
-    .icon-medium {
-      font-size: 2em;
-    }
 </style>


### PR DESCRIPTION
closes [MarkBind #986](https://github.com/MarkBind/markbind/issues/986) (specifications of sizes can also be found there). 

This is an enhancement to box icons.
The following classes can be made use of when adding icons to boxes - `icon-medium`, `icon-large`, `icon-extra-large`.