### PR TITLE
Organize searchbar interface results by page

### DIFF
--- a/src/SearchbarPageItem.vue
+++ b/src/SearchbarPageItem.vue
@@ -1,0 +1,116 @@
+<template>
+  <div v-if="item.heading" class="heading">
+    <div class="heading-text">{{ item.heading.text }}</div>
+    <div class="heading-text-items">
+      <small v-html="highlight(item.heading.text, value)"></small>
+      <br />
+      <small v-for="(keyword, index) in item.keywords" :key="index">
+        <span v-html="highlight(keyword, value)"></span>
+        <br />
+      </small>
+    </div>
+  </div>
+  <div v-else>
+    <span class="page-title" v-html="highlight(item.title, value)"></span>
+    <br v-if="item.keywords" />
+    <small v-if="item.keywords" v-html="highlight(item.keywords, value)"></small>
+    <hr class="page-headings-separator" />
+  </div>
+</template>
+
+<script>
+export default {
+  props: {
+    item: {
+      type: Object,
+      default: null,
+    },
+    value: {
+      type: String,
+      default: '',
+    },
+  },
+  methods: {
+    highlight(value, phrase) {
+      function getMatchIntervals() {
+        const regexes = phrase.split(' ')
+          .filter(searchKeyword => searchKeyword !== '')
+          .map(searchKeyword => searchKeyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+          .map(searchKeyword => new RegExp(`(${searchKeyword})`, 'gi'));
+        const matchIntervals = [];
+        regexes.forEach((regex) => {
+          let match = regex.exec(value);
+          while (match !== null) {
+            if (match.index === regex.lastIndex) {
+              break;
+            }
+            matchIntervals.push({ start: match.index, end: regex.lastIndex });
+            match = regex.exec(value);
+          }
+        });
+        return matchIntervals;
+      }
+      // https://www.geeksforgeeks.org/merging-intervals/
+      function mergeOverlappingIntervals(intervals) {
+        if (intervals.length <= 1) {
+          return intervals;
+        }
+        return intervals
+          .sort((a, b) => a.start - b.start)
+          .reduce((stack, current) => {
+            const top = stack[stack.length - 1];
+            if (!top || top.end < current.start) {
+              stack.push(current);
+            } else if (top.end < current.end) {
+              top.end = current.end;
+            }
+            return stack;
+          }, []);
+      }
+      const matchIntervals = mergeOverlappingIntervals(getMatchIntervals());
+      let highlightedValue = value;
+      // Traverse from back to front to avoid the positioning going out of sync
+      for (let i = matchIntervals.length - 1; i >= 0; i -= 1) {
+        highlightedValue = `${highlightedValue.slice(0, matchIntervals[i].start)}<mark>`
+          + `${highlightedValue.slice(matchIntervals[i].start, matchIntervals[i].end)}</mark>`
+          + `${highlightedValue.slice(matchIntervals[i].end)}`;
+      }
+      return highlightedValue;
+    },
+  },
+};
+</script>
+
+<style scoped>
+  .mark {
+    padding: 0 !important;
+  }
+
+  .heading {
+    padding: 0 0 0.1rem 0.2rem;
+  }
+
+  .heading-text {
+    display: inline-block;
+    width: 40%;
+    white-space: normal;
+    vertical-align: top;
+  }
+
+  .heading-text-items {
+    display: inline-block;
+    width: calc(60% - 0.7rem);
+    white-space: normal;
+    border-left: 1px solid #ddd;
+    padding-left: 0.5rem;
+  }
+
+  .page-title {
+    font-size: 1.05rem;
+    font-weight: bold;
+  }
+
+  .page-headings-separator {
+    margin: 0.2rem 0;
+  }
+</style>


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Resolves https://github.com/MarkBind/markbind/issues/994
Requires https://github.com/MarkBind/markbind/pull/1006

**What is the rationale for this request?**
Search results are not organized by page, resulting in a less pleasant user experience.


**What changes did you make? (Give an overview)**
- Moved `searchbarTemplate` to its own seperate file for better maintainability.
- Rewrite `searchbarTemplate`'s template to organize results by page
- Changed result sorting to sort first by the total number of matches in a page, then by the respective number of matches for the page's headings ( and keywords ).
- Use the page src as a fallback title for the title, which prevents this:
![emptytitle](https://user-images.githubusercontent.com/3306138/73521418-de83d980-4440-11ea-8fbb-e4f428070221.png)

End result:
![searchbar](https://user-images.githubusercontent.com/3306138/73521448-ef344f80-4440-11ea-99e1-001130be83e5.png)

**Provide some example code that this change will affect:**

Template of `searchbarTemplate`
```html
<div v-if="item.heading" class="heading">
  <div class="heading-text">{{ item.heading.text }}</div>
  <div class="heading-text-items">
    <small v-html="highlight(item.heading.text, value)"></small>
    <br />
    <small v-for="(keyword, index) in item.keywords" :key="index">
      <span v-html="highlight(keyword, value)"></span>
      <br />
    </small>
  </div>
</div>
<div v-else>
...
</div>
```

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
The test site has a good amount of keywords / headings used to test the sorting algorithm.
[This version](https://pastebin.com/DVWDNp6J) of `SearchbarPageItem` displays the number of matches beside the entry, if needed

The searchbar should appear as is in the above image otherwise.

**Proposed commit message: (wrap lines at 72 characters)**

Organize searchbar interface results by page

Search results belonging to the same page display as individual entries,
showing the page title multiple times.
Results are also not organized by page, but by the total number of
matches in the page title, heading and keywords with the search term.
When a page title is not specified in the site config, the search result
displays an empty block of vertical space.

This can lead to a less pleasant user experience with the searchbar.

Let’s redesign the searchbar user interface, organizing results by page.
Results belonging to the same page are sorted by the number of
matches, and pages are sorted according to the total number of its
matches in the page’s headings and keywords.
Let’s use the page’s src as a fallback title if the title is absent.