### PR TITLE
Fix fontawesome icons not showing underlines for triggers

### DIFF
--- a/src/Tooltip.vue
+++ b/src/Tooltip.vue
@@ -45,8 +45,7 @@ export default {
   },
   mounted () {
     if (this.$refs.trigger) {
-      this.$refs.trigger.style['-webkit-text-decoration'] = 'underline dotted'
-      this.$refs.trigger.style['text-decoration'] = 'underline dotted'
+      this.$refs.trigger.style['border-bottom'] = '1px dashed currentColor'
     }
   }
 }

--- a/src/trigger.vue
+++ b/src/trigger.vue
@@ -34,11 +34,9 @@
 
       if (this.trigger === 'click') {
         this.$refs.trigger.style['cursor'] = 'pointer'
-        this.$refs.trigger.style['-webkit-text-decoration'] = 'underline dashed';
-        this.$refs.trigger.style['text-decoration'] = 'underline dashed';
+        this.$refs.trigger.style['border-bottom'] = '1px dashed currentColor';
       } else {
-        this.$refs.trigger.style['-webkit-text-decoration'] = 'underline dotted';
-        this.$refs.trigger.style['text-decoration'] = 'underline dotted'
+        this.$refs.trigger.style['border-bottom'] = '1px dashed currentColor'
       }
     },
     methods: {


### PR DESCRIPTION
Fixes https://github.com/MarkBind/markbind/issues/995.

Changes text underline to a border-bottom for the entire span component so icons get underlined too. 😄 

<img width="753" alt="Screen Shot 2020-02-03 at 12 22 42 PM" src="https://user-images.githubusercontent.com/28432397/73625538-3e1bf800-4680-11ea-987a-33541e7ff3c1.png">


