### PR TITLE
Implement no-* attributes for <box>

### DIFF
--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -15,7 +15,7 @@
         </div>
         <div v-if="horizontalDividerBool" class="horizontal-divider" :class="boxStyle" aria-hidden="true"></div>
         <div :class="['box-body-wrapper', { 'alert-dismissible': dismissible && !headerBool, 'box-body-wrapper-with-heading': headerBool }]">
-            <div v-show="!isDefault && !headerBool" class="icon-wrapper" :class="[iconStyle]">
+            <div v-show="hasIcon && !headerBool" class="icon-wrapper" :class="[iconStyle]">
                 <slot name="_icon">
                     <span v-html="iconType"></span>
                 </slot>

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -1,7 +1,7 @@
 <template>
-    <div class="alert box-container" :class="[boxStyle, addClass, lightStyle, seamlessStyle]" :style="customStyle">
+    <div class="alert box-container" :class="[boxStyle, addClass, lightStyle, seamlessStyle, , noBackgroundStyle, noBorderStyle]" :style="customStyle">
         <div v-if="headerBool" :class="['box-header-wrapper', { 'alert-dismissible': dismissible }]">
-            <div v-show="!isDefault" class="icon-wrapper" :class="[iconStyle]">
+            <div v-show="hasIcon" class="icon-wrapper" :class="[iconStyle]">
                 <slot name="_icon">
                     <span v-html="iconType"></span>
                 </slot>
@@ -79,11 +79,20 @@
         type: Boolean,
         default: false,
       },
+      noIcon: {
+        type: Boolean,
+        default: false,
+      },
+      noBackground: {
+        type: Boolean,
+        default: false,
+      },
+      noBorder: {
+        type: Boolean,
+        default: false,
+      }
     },
     computed: {
-      isDefault() {
-        return this.type === 'none'
-      },
       isSeamless() {
         return !this.light && this.seamless;
       },
@@ -140,7 +149,7 @@
           style.borderColor = this.backgroundColor;
         }
         if (this.borderColor) {
-          style.borderColor = this.borderColor;
+          style.border = `1px solid ${this.borderColor}`;
         }
         if (this.borderLeftColor) {
           style.borderLeft = `5px solid ${this.borderLeftColor}`;
@@ -162,6 +171,11 @@
         }
         return '';
       },
+      hasIcon() {
+        // this.$slots._icon is either undefined or an object
+        const isIconSlotFilled = !!this.$slots._icon;
+        return !this.noIcon || isIconSlotFilled;
+      },
       iconType() {
         switch (this.type) {
           case 'wrong':
@@ -179,12 +193,24 @@
           case 'definition':
             return '<i class="fas fa-atlas"></i>';
           default:
-            return '<i class="fas fa-exclamation"></i>';
+            return '';
         }
       },
       iconStyle() {
         if (this.iconSize) {
           return `fa-${this.iconSize}`;
+        }
+        return '';
+      },
+      noBackgroundStyle() {
+        if (this.noBackground) {
+          return 'no-background';
+        }
+        return '';
+      },
+      noBorderStyle() {
+        if (this.noBorder) {
+          return 'no-border';
         }
         return '';
       }
@@ -297,6 +323,14 @@
         width: calc(100% - 2.5rem);
         height: 3px;
     }
+
+    .no-background {
+      background: none;
+    }
+
+    .no-border {
+      border: none;
+    }
 </style>
 
 <!-- TODO move this once we upgrade vue-loader version for scoped deep selectors -->
@@ -305,3 +339,4 @@
         margin-bottom: 0;
     }
 </style>
+

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="alert box-container" :class="[boxStyle, addClass, lightStyle, seamlessStyle, , noBackgroundStyle, noBorderStyle]" :style="customStyle">
+    <div class="alert box-container" :class="[boxStyle, addClass, lightStyle, seamlessStyle, noBackgroundStyle, noBorderStyle]" :style="customStyle">
         <div v-if="headerBool" :class="['box-header-wrapper', { 'alert-dismissible': dismissible }]">
             <div v-show="hasIcon" class="icon-wrapper" :class="[iconStyle]">
                 <slot name="_icon">

--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -339,4 +339,3 @@
         margin-bottom: 0;
     }
 </style>
-


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [X] Enhancement to an existing feature

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes MarkBind/markbind#978
Requires https://github.com/MarkBind/markbind/pull/1042
Requires https://github.com/MarkBind/vue-strap/pull/118 (will wait before it gets merged)

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

Support `no-icon`, `no-background`, `no-border` attributes helps to omit the respective aspects more conveniently.

**What changes did you make? (Give an overview)**

When no-icon is absent **or** icon slot is filled, the icon div will be rendered.
Because it is an **or** statement, the presence of `icon="..."` will take precedence over `no-icon`

When no-background or no-border is applied, `.no-background` or a `.no-border` CSS class is applied respectively. Due to the position of CSS rules, it overrides styles applied by bootstrap or by ourselves. Since customs style are applied afterwards via `style="..."`, it is applied last. Thus any style defined by `background`, `border-color`, `border-left-color` take precedence over `no-background` or `no-border`.  

Corresponding documentation in https://github.com/MarkBind/markbind/pull/1042

**Provide some example code that this change will affect:**
<!-- Paste the example code below: -->

You can view the syntax at https://gist.github.com/nbriannl/9369aab530e032bc93070cd8958949e3
and the corresponding output at https://nbriannl.github.io/markbind-plain-site/

**Is there anything you'd like reviewers to focus on?**

**Proposed commit message: (wrap lines at 72 characters)**

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

Implement no-* attributes for <box>

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->
