### PR TITLE
Align and use fixed widths for icons

### DIFF
--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -219,7 +219,9 @@
 
     .icon-wrapper {
         display: flex;
+        justify-content: center;
         margin-right: .5em;
+        width: 1em;
     }
 
     .contents {


### PR DESCRIPTION
Fixes [Markbind #1041](https://github.com/MarkBind/markbind/issues/1041)

Added fixed width and center-aligned icon inside the icon wrapper.