### PR TITLE
Add panel expand and collapse transitions

### DIFF
--- a/src/Retriever.vue
+++ b/src/Retriever.vue
@@ -59,10 +59,12 @@ export default {
             template: `<div>\n${result}\n</div>`,
           })
           new tempComponent().$mount(this.$el);
+          this.$emit('src-loaded');
         })
         .fail((error) => {
           console.error(error.responseText)
           this.$el.innerHTML = `<strong>Error</strong>: Failed to retrieve content from source: <em>${this.src}</em>`
+          this.$emit('src-loaded');
         });
     }
   },

--- a/src/panels/NestedPanel.vue
+++ b/src/panels/NestedPanel.vue
@@ -25,8 +25,8 @@
               </div>
               <div class="button-wrapper">
                   <slot name="button">
-                      <panel-switch v-show="isExpandableCard && !noSwitchBool && !showCaret" :is-open="localExpanded"
-                                    @click.native.stop.prevent="expand()"
+                      <panel-switch v-show="isExpandableCard && !noSwitchBool && !showCaret"
+                                    :is-open="localExpanded"
                                     :is-light-bg="isLightBg"></panel-switch>
                       <button type="button" :class="['close-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
                               v-show="isSeamless ? onHeaderHover : (!noCloseBool)"
@@ -41,21 +41,28 @@
                   </slot>
               </div>
           </div>
-          <template v-if="preloadBool || isCached">
+          <transition @before-enter="beforeExpand"
+                      @enter="duringExpand"
+                      @leave="duringCollapse"
+                      v-if="preloadBool || wasRetrieverLoaded"
+          >
               <div class="card-collapse"
                    ref="panel"
                    v-show="localExpanded"
               >
                   <div class="card-body">
                       <slot></slot>
-                      <retriever v-if="hasSrc" ref="retriever" :src="src" :fragment="fragment"></retriever>
+                      <retriever v-if="hasSrc"
+                                 ref="retriever"
+                                 :src="src"
+                                 :fragment="fragment"
+                                 @src-loaded="setMaxHeight" />
                       <panel-switch v-show="isExpandableCard && bottomSwitchBool" :is-open="localExpanded"
-                                    @click.native.stop.prevent="collapseThenScrollIntoViewIfNeeded()"
-                      ></panel-switch>
+                                    @click.native.stop.prevent="toggle()" />
                   </div>
                   <hr v-show="isSeamless" />
               </div>
-          </template>
+          </transition>
       </div>
   </span>
 </template>
@@ -113,6 +120,13 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+    .card-collapse {
+        overflow: hidden;
+        transition: max-height 0.7s ease-in-out;
+    }
+</style>
 
 <style>
     .card-heading {

--- a/src/panels/PanelSwitch.vue
+++ b/src/panels/PanelSwitch.vue
@@ -27,7 +27,6 @@
     methods: {
       toggle () {
         this.isOpen = !this.isOpenBool
-        this.$emit('is-open-event', this, this.isOpenBool)
       }
     },
     created () {


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Enhancement to an existing feature

Resolves https://github.com/MarkBind/markbind/issues/486

**What is the rationale for this request?**
To add transitions for collapsing and expanding the panel,
and also animate the user's scroll position back to the panel when the panel is collapsed ( if out of view )

**What changes did you make? (Give an overview)**

![paneltransitiondemo](https://user-images.githubusercontent.com/3306138/75149573-504bfc00-573d-11ea-8d99-378fd6454e22.gif)
( framerate drastically reduced due to 10mb limit )

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
- The panels should be testing according to its archtype ( minimal, seamless, all others )
 
Combinations to experiment with that has an effect on the code executed:
- `minimized`
- `expanded`
- The above with / without a `src` attribute
- none of the above

**Proposed commit message: (wrap lines at 72 characters)**

Add panel expand and collapse transitions

When a panel is expanded or collapsed, the panel’s content is also
instantly shown or hidden.

Moreover, when a panel is collapsed, the scroll position of the browser
stays the same, possibly showing the user a distant area of the page.
This can cause the reader to feel lost after collapsing the panel.

Let’s add panel expand and collapse transitions to panels.
Additionally, when a panel is collapsed, the reader’s scroll position is
smoothly animated back to the collapsed panel if the top of the panel
is out of the reader’s view.