### PR TITLE
Add zero bottom margin to last child of tip boxes

### DIFF
--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -272,6 +272,10 @@
         padding-left: 12px;
     }
 
+    .contents > :last-child {
+        margin-bottom: 0;
+    }
+
     .alert-default {
         color: #24292e;
         background-color: #f6f8fa;


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

**What is the rationale for this request?**

To collapse the space between the last child of a box and the bottom, which is caused
![boxesTooTall](https://user-images.githubusercontent.com/3306138/75330481-2240f600-58bc-11ea-8d13-42dc985247fa.png)

by extra bottom margin added by the default bootstrap styles
![boxesCause](https://user-images.githubusercontent.com/3306138/75330497-2836d700-58bc-11ea-8f94-61c93783b58d.png)

E.g. We may want to use markdown inside the box, which would require leaving an empty line.
This causes "lorem ipsum..." to be rendered into `<p>` tag, which causes the issue.
```
<box>

Lorem _ipsum_ lorem ipsum lorem ipsum lorem ipsum
</box>
```

**What changes did you make? (Give an overview)**
```css
.contents > :last-child {
  margin-bottom: 0;
}
```

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
na

**Proposed commit message: (wrap lines at 72 characters)**
Add zero bottom margin to last child of tip boxes

