### PR TITLE
Change tooltip to have underline dotted trigger

### DIFF
--- a/src/Tooltip.vue
+++ b/src/Tooltip.vue
@@ -44,7 +44,8 @@ export default {
   },
   mounted () {
     if (this.$refs.trigger) {
-      this.$refs.trigger.style['border-bottom'] = '1px dashed currentColor'
+      this.$refs.trigger.style['-webkit-text-decoration'] = 'underline dotted';
+      this.$refs.trigger.style['text-decoration'] = 'underline dotted';
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/MarkBind/markbind/issues/1053

```
Change tooltip to have underline dotted trigger

Tooltips and popovers should have the same style triggers.

Let's change tooltips to follow the popover style.
```