### PR TITLE
Fix cropped nested expandable content in panels

### DIFF
--- a/src/panels/MinimalPanel.vue
+++ b/src/panels/MinimalPanel.vue
@@ -38,6 +38,8 @@
       </div>
       <transition @before-enter="beforeExpandMinimal"
                   @enter="duringExpand"
+                  @after-enter="afterExpand"
+                  @before-leave="beforeCollapse"
                   @leave="duringCollapse"
                   @after-leave="afterCollapseMinimal"
                   v-if="preloadBool || wasRetrieverLoaded"

--- a/src/panels/NestedPanel.vue
+++ b/src/panels/NestedPanel.vue
@@ -43,6 +43,8 @@
           </div>
           <transition @before-enter="beforeExpand"
                       @enter="duringExpand"
+                      @after-enter="afterExpand"
+                      @before-leave="beforeCollapse"
                       @leave="duringCollapse"
                       v-if="preloadBool || wasRetrieverLoaded"
           >

--- a/src/panels/PanelBase.js
+++ b/src/panels/PanelBase.js
@@ -121,6 +121,22 @@ export default {
       window.open(this.popupUrl);
     },
     setMaxHeight() {
+      // Don't play the transition for this case as the loading should feel 'instant'
+      if (this.expandedBool) {
+        this.$refs.panel.style.maxHeight = 'max-content';
+        return;
+      }
+      
+      /*
+      Otherwise, since the vue transition is dependent on localExpanded, we have to manually
+      set our own transition end handlers here for the initial loading of the content.
+      */
+      const onExpandDone = () => {
+        this.$refs.panel.style.maxHeight = 'max-content';
+        this.$refs.panel.removeEventListener('transitionend', onExpandDone);
+      };
+      
+      this.$refs.panel.addEventListener('transitionend', onExpandDone);
       this.$refs.panel.style.maxHeight = `${this.$refs.panel.scrollHeight}px`;
     },
     beforeExpand(el) {
@@ -128,6 +144,12 @@ export default {
     },
     duringExpand(el) {
       jQuery("html").stop();
+      el.style.maxHeight = `${el.scrollHeight}px`;
+    },
+    afterExpand(el) {
+      el.style.maxHeight = 'max-content';
+    },
+    beforeCollapse(el) {
       el.style.maxHeight = `${el.scrollHeight}px`;
     },
     duringCollapse(el) {
@@ -154,9 +176,4 @@ export default {
     this.wasRetrieverLoaded = this.localExpanded; // If it is expanded, load the retriever immediately.
     this.localMinimized = this.minimizedBool;
   },
-  mounted() {
-    // For this case, we want to set and calculate the maximum height only after the
-    // panel has been mounted.
-    if (this.expandedBool && !this.hasSrc) this.setMaxHeight();
-  }
 };


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Bug fix

Fixes https://github.com/MarkBind/markbind/issues/1166

**What changes did you make? (Give an overview)**
Reset the `max-height` of the panel content wrapper to its appropriate value
after expanding the panel, so that it can react to changes in the height of its content.

**Provide some example code that this change will affect:**

Resetting of `maxHeight` to appropriate values:
( it needs to be reset before collapsing as well so that the collapse animation would play )
```js
afterExpand(el) {
  el.style.maxHeight = 'max-content';
},
beforeCollapse(el) {
  el.style.maxHeight = `${el.scrollHeight}px`;
},
```

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
- nested panels' content should no longer be 'cropped out' of main panel

**Proposed commit message: (wrap lines at 72 characters)**

<!--
    See this link for more info on how to write a good commit message:
    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
-->

<!--
    Some of the responses that you gave to the previous questions might
    provide you with the information needed to craft your commit message.
-->


Fix cropped nested expandable content in panels

After finishing the panel expand animation or before the collapse
animation, the max height of the panel content wrapper is not
reset to their appropriate values.
This causes expandable content inside panels, such as nested panels.

Let’s do so, allowing the outer panel to react to changes in its
content height after expanding it.