### PR TITLE
Fix panel max height for older browsers

### DIFF
--- a/src/panels/PanelBase.js
+++ b/src/panels/PanelBase.js
@@ -123,7 +123,7 @@ export default {
     setMaxHeight() {
       // Don't play the transition for this case as the loading should feel 'instant'
       if (this.expandedBool) {
-        this.$refs.panel.style.maxHeight = 'max-content';
+        this.$refs.panel.style.maxHeight = 'none';
         return;
       }
       
@@ -132,7 +132,7 @@ export default {
       set our own transition end handlers here for the initial loading of the content.
       */
       const onExpandDone = () => {
-        this.$refs.panel.style.maxHeight = 'max-content';
+        this.$refs.panel.style.maxHeight = 'none';
         this.$refs.panel.removeEventListener('transitionend', onExpandDone);
       };
       
@@ -147,7 +147,7 @@ export default {
       el.style.maxHeight = `${el.scrollHeight}px`;
     },
     afterExpand(el) {
-      el.style.maxHeight = 'max-content';
+      el.style.maxHeight = 'none';
     },
     beforeCollapse(el) {
       el.style.maxHeight = `${el.scrollHeight}px`;


### PR DESCRIPTION
Follow up to #137, for some older browser versions ( tested on edge v44 ) that don't respect `max-content` - `max-height: none` achieves the same purpose for the fix

**Proposed Commit Message**
Fix panel max height for older browsers
