### PR TITLE
Refactor panel onHeaderHover to css

### DIFF
--- a/src/panels/MinimalPanel.vue
+++ b/src/panels/MinimalPanel.vue
@@ -9,12 +9,12 @@
         </slot>
       </button>
     </div>
-    <div v-show="!localMinimized" class="card card-flex" @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
+    <div v-show="!localMinimized" class="card card-flex">
       <div :class="['header-wrapper', { 'header-wrapper-bottom': isHeaderAtBottom, 'header-toggle': isExpandableCard }]"
            @click.prevent.stop="isExpandableCard && toggle()">
         <transition name="header-fade">
           <span v-show="!isHeaderAtBottom" ref="headerWrapper"
-                :class="['card-title', 'card-title-transparent', { 'card-title-opaque': onHeaderHover, 'ellipses': !hasHeaderBool }]">
+                :class="['card-title', 'card-title-transparent', { 'ellipses': !hasHeaderBool }]">
             <slot name="header">
               <span class="card-title-inline"><slot name="_header"></slot></span>
               <span v-show="showDownSwitch" aria-hidden="true"
@@ -22,7 +22,7 @@
             </slot>
           </span>
         </transition>
-        <div :class="['button-wrapper', { 'button-wrapper-expanded': isHeaderAtBottom, 'button-wrapper-visible': onHeaderHover }]">
+        <div :class="['button-wrapper', { 'button-wrapper-expanded': isHeaderAtBottom }]">
           <slot name="button">
             <button v-show="!noCloseBool" class="minimal-button" type="button" @click.stop="close()">
               <span class="glyphicon glyphicon-remove minimal-close-button" aria-hidden="true"></span>
@@ -132,7 +132,7 @@ export default {
     transition: opacity 0.5s;
   }
 
-  .card-title-opaque {
+  .card:hover .card-title-transparent {
     opacity: 1;
   }
 
@@ -145,7 +145,7 @@ export default {
   }
 
   .header-fade-leave-to {
-    opacity: 0;
+    opacity: 0 !important;
   }
 
   .card-title-inline {
@@ -187,14 +187,14 @@ export default {
     vertical-align: text-top;
   }
 
-  .button-wrapper-visible {
-    opacity: 1;
-  }
-
   .button-wrapper-expanded {
     padding-left: 0;
     border: 0;
     margin-left: 0;
+  }
+  
+  .card:hover .button-wrapper {
+    opacity: 1;
   }
 
   .header-toggle {

--- a/src/panels/NestedPanel.vue
+++ b/src/panels/NestedPanel.vue
@@ -11,8 +11,7 @@
       </div>
       <div :class="['card', { 'expandable-card': isExpandableCard }, borderType]" v-show="!localMinimized">
           <div :class="['card-header',{'header-toggle':isExpandableCard}, cardType, borderType]"
-               @click.prevent.stop="isExpandableCard && toggle()"
-               @mouseover="onHeaderHover = true" @mouseleave="onHeaderHover = false">
+               @click.prevent.stop="isExpandableCard && toggle()">
               <div class="caret-wrapper">
                   <span :class="['glyphicon', localExpanded ? 'glyphicon-chevron-down' : 'glyphicon-chevron-right']" v-if="showCaret"></span>
               </div>
@@ -28,13 +27,17 @@
                       <panel-switch v-show="isExpandableCard && !noSwitchBool && !showCaret"
                                     :is-open="localExpanded"
                                     :is-light-bg="isLightBg"></panel-switch>
-                      <button type="button" :class="['close-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
-                              v-show="isSeamless ? onHeaderHover : (!noCloseBool)"
+                      <button type="button"
+                              class="close-button btn"
+                              :class="[isLightBg ? 'btn-outline-secondary' : 'btn-outline-light', { 'seamless-button': isSeamless }]"
+                              v-show="!noCloseBool"
                               @click.stop="close()">
                           <span class="glyphicon glyphicon-remove" aria-hidden="true"></span>
                       </button>
-                      <button type="button" :class="['popup-button', 'btn', isLightBg ? 'btn-outline-secondary' : 'btn-outline-light']"
-                              v-show="((this.popupUrl !== null) && (!isSeamless || onHeaderHover))"
+                      <button type="button"
+                              class="popup-button btn"
+                              :class="[isLightBg ? 'btn-outline-secondary' : 'btn-outline-light', { 'seamless-button': isSeamless }]"
+                              v-show="this.popupUrl"
                               @click.stop="openPopup()">
                           <span class="glyphicon glyphicon-new-window" aria-hidden="true"></span>
                       </button>
@@ -113,12 +116,6 @@ export default {
     isLightBg() {
       return this.cardType === 'bg-light' || this.cardType === 'bg-white' || this.cardType === 'bg-warning';
     },
-    showCloseButton() {
-      if (!this.isSeamless) {
-        return !this.noCloseBool;
-      }
-      return this.onHeaderHover;
-    },
   },
 };
 </script>
@@ -127,6 +124,15 @@ export default {
     .card-collapse {
         overflow: hidden;
         transition: max-height 0.7s ease-in-out;
+    }
+    
+    .seamless-button {
+        opacity: 0;
+        transition: 0.3s opacity;
+    }
+    
+    .card-header:hover .seamless-button {
+        opacity: 1;
     }
 </style>
 

--- a/src/panels/PanelBase.js
+++ b/src/panels/PanelBase.js
@@ -89,7 +89,6 @@ export default {
   },
   data() {
     return {
-      onHeaderHover: false,
       localExpanded: false,
       localMinimized: false,
       wasRetrieverLoaded: false,


### PR DESCRIPTION
**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**

• [x] Others:

**What is the rationale for this request?**
The panel component uses a data variable `onHeaderHover` to determine whether to show / hide certain buttons. This variable is only toggled upon `mouseenter` / `mouseleave` of the panel, and only affects css of the buttons.
We could instead use css pseudo selectors to achieve this

**What changes did you make? (Give an overview)**
- refactor the hiding / displaying of buttonsto use css selectors
  - fixes `no-close` not being respected by seamless panels simultaneously

**Is there anything you'd like reviewers to focus on?**
na

**Testing instructions:**
na currently

**Proposed commit message: (wrap lines at 72 characters)**
Refactor panel onHeaderHover to css

The panel component uses a data variable, onHeaderHover, to trigger
css changes of its various buttons.

Let’s refactor this to use the css hover pseudo selector instead, which
increases code readability and maintenance of the component.