### PR TITLE
Use min-width property instead of width

### DIFF
--- a/src/TipBox.vue
+++ b/src/TipBox.vue
@@ -279,7 +279,7 @@
         display: flex;
         justify-content: center;
         margin-right: .5em;
-        width: 1em;
+        min-width: 1em;
     }
 
     .close-with-heading {


### PR DESCRIPTION
Fixes [Markbind/issue#1172](https://github.com/MarkBind/markbind/issues/1172)

Uses the `min-width` property on the icon wrapper to allow custom content like thumbnails, images and gifs as icons to scale well while also ensuring font-awesome icons still abide by the width and are properly aligned.

<img width="580" alt="Screenshot 2020-04-06 at 5 58 14 PM" src="https://user-images.githubusercontent.com/21968718/78546593-43d4bc00-7830-11ea-9599-1ac231d8c222.png">

corresponding markbind syntax - 
```html
<box seamless type="info">
    <thumbnail circle slot="icon" text=":book:" background="#dff5ff" size="50"/>
    thumbnail as icon; not using icon-size
</box>

<box seamless type="success">
    <img slot="icon" src="https://img.icons8.com/cute-clipart/64/000000/book.png"/>
    book icon with without icon-size
</box>

<box seamless type="warning">
  <img slot="icon" src="https://icons8.com/vue-static/landings/animated-icons/icons/cloud/cloud.gif"></img>
  Cloud gif as custom content
</box>

<box seamless icon-size="2x" type="info">
    Icon with size = 2x
</box>

<box seamless icon-size="2x" type="success">
    Icon with size = 2x
</box>
```