### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,51 @@
+**What is the purpose of this pull request? (put "X" next to an item, remove the rest)**
+
+• [ ] Bug fix
+• [ ] New feature
+• [ ] Enhancement to an existing feature
+• [ ] Other, please explain:
+
+<!--
+    If this pull request is addressing an issue, link to the issue: "Fixes https://github.com/MarkBind/markbind/issues/XXX" or "Resolves https://github.com/MarkBind/markbind/issues/XXX"
+-->
+
+
+<!--
+    Please ensure your pull request is ready:
+    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
+    - Feature PR **must** add a page to the user guide for demo.
+    - Enhancement PR **should** update the user guide.
+
+    Otherwise, prefix your PR title with "[WIP]".
+-->
+
+**What is the rationale for this request?**
+
+
+**What changes did you make? (Give an overview)**
+
+
+**Provide some example code that this change will affect:**
+
+<!-- Paste the example code below: -->
+```js
+
+```
+
+**Is there anything you'd like reviewers to focus on?**
+
+
+**Testing instructions:**
+
+
+**Proposed commit message: (wrap lines at 72 characters)**
+
+<!--
+    See this link for more info on how to write a good commit message:
+    https://oss-generic.github.io/process/docs/FormatsAndConventions.html#commit-message
+-->
+
+<!--
+    Some of the responses that you gave to the previous questions might
+    provide you with the information needed to craft your commit message.
+-->


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

•  [ ] Documentation update
•  [ ] Bug fix
•  [ ] New feature
•  [ ] Enhancement to an existing feature
• [x] Other, please explain: Improvement of Pull Requests 

<!--
    If this pull request is addressing an issue, link to the issue: "Fixes #xxx" or "Resolves #xxx"
-->

Fixes https://github.com/MarkBind/markbind/issues/1214

<!--
    Please ensure your pull request is ready:
    - Bug fix PR that is non-trivial **should** add a page or unit test for regression testing.
    - Feature PR **must** add a page to the user guide for demo.
    - Enhancement PR **should** update the user guide.

    Otherwise, prefix your PR title with "[WIP]".
-->

**What is the rationale for this request?**

It would be nice to have a pull request template for vue-strap like the one we have for markbind

**What changes did you make? (Give an overview)**

Add GitHub pull request template

**Provide some example code that this change will affect:**

\-

**Is there anything you'd like reviewers to focus on?**

It's the same template as MarkBind's, I'm sure we all copy and paste from MarkBind. 
Except for the referencing of links, we have to put the full URL since it's another repo

**Testing instructions:**

\-